### PR TITLE
fix(qwen-proxy): rotate Baxia token on empty-exhaustion (recover from sustained token-burn)

### DIFF
--- a/packages/qwen-proxy/bin/qwen-proxy.ts
+++ b/packages/qwen-proxy/bin/qwen-proxy.ts
@@ -66,6 +66,9 @@ async function main() {
     // No-op auth scheduler (guest has no JWT to refresh)
     const scheduler = {
       refreshOnDemand: async () => ({ bearer: "guest", expiresAt: null }),
+      // Rotate the Baxia token on empty-exhaustion: in guest mode the token/session
+      // can get flagged by Baxia, and a fresh Chromium spawn recovers it without a restart.
+      refreshBaxiaToken: async () => { await baxia.ensureToken({ forceRefresh: true }); },
     };
 
     // Per-account request throttle (look-human): paces dispatches to reduce

--- a/packages/qwen-proxy/src/pool/retry.ts
+++ b/packages/qwen-proxy/src/pool/retry.ts
@@ -6,6 +6,8 @@ import type { RequestThrottle } from "./throttle";
 /** Minimal scheduler contract retry needs: on-demand token refresh. */
 export interface RetryScheduler {
   refreshOnDemand(id: number): Promise<{ bearer: string; expiresAt: number | null }>;
+  /** Best-effort Baxia token rotation — called on empty-exhaustion so the next request gets a fresh, unflagged token. Optional (absent in tests). */
+  refreshBaxiaToken?(): Promise<void>;
 }
 
 export interface RetryDeps {
@@ -77,6 +79,10 @@ export async function withPoolRetry<T>(
           cooldownMs: emptyCooldownMs,
         });
         await deps.pool.markEmptyAndSwitch(id, emptyCooldownMs);
+        // Rotate the Baxia token so the next request (after cooldown) gets a fresh,
+        // unflagged token — recovers the sustained-token-burn "stuck" state without a restart.
+        try { await deps.scheduler.refreshBaxiaToken?.(); }
+        catch (e) { deps.log.error("baxia token refresh failed after empty-exhaustion", { error: String(e) }); }
         throw new RateLimitError("upstream returned an empty completion after retries (likely rate-limited, try again later)", { status: 429, retryAfterMs: emptyCooldownMs });
       }
 
@@ -181,6 +187,9 @@ export async function* withPoolRetryStream(
         .catch(() => {
           deps.log.error("background markEmptyAndSwitch failed");
         });
+      // Rotate the Baxia token so the next request gets a fresh, unflagged token.
+      try { await deps.scheduler.refreshBaxiaToken?.(); }
+      catch (e) { deps.log.error("baxia token refresh failed after empty-exhaustion", { error: String(e) }); }
       yield { done: true, extra: { rateLimited: true } };
       return;
     }

--- a/packages/qwen-proxy/tests/pool/retry.test.ts
+++ b/packages/qwen-proxy/tests/pool/retry.test.ts
@@ -182,7 +182,15 @@ describe("withPoolRetry empty-completion (non-stream)", () => {
       earliestReEnableAt: () => null,
     } as unknown as PoolLike;
 
-    const deps = makeDeps({ pool, config: { emptyCooldownMs: 10_000, emptyRetryMax: 3, emptyRetryGapMs: 0 } });
+    let refreshBaxiaCalled = 0;
+    const deps = makeDeps({
+      pool,
+      config: { emptyCooldownMs: 10_000, emptyRetryMax: 3, emptyRetryGapMs: 0 },
+      scheduler: {
+        refreshOnDemand: async () => ({ bearer: "", expiresAt: null }),
+        refreshBaxiaToken: async () => { refreshBaxiaCalled++; },
+      },
+    });
     let callCount = 0;
 
     await expect(
@@ -194,6 +202,29 @@ describe("withPoolRetry empty-completion (non-stream)", () => {
 
     expect(callCount).toBe(4); // 1 initial + 3 retries
     expect(markEmptyCalled).toBe(1); // exhaustion
+    expect(refreshBaxiaCalled).toBe(1); // Baxia token rotated on exhaustion
+  });
+
+  it("empty-exhaustion rotates the Baxia token even if refresh rejects (best-effort)", async () => {
+    const pool: PoolLike = {
+      id: 0, bearer: "guest", expiresAt: null,
+      getActiveAccount: () => ({ id: 0, bearer: "guest", expiresAt: null }),
+      markEmptyAndSwitch: async () => ({ newActiveId: null, earliestReEnableAt: null }),
+      markSuccess: () => {},
+      earliestReEnableAt: () => null,
+    } as unknown as PoolLike;
+    const deps = makeDeps({
+      pool,
+      config: { emptyCooldownMs: 10_000, emptyRetryMax: 0, emptyRetryGapMs: 0 },
+      scheduler: {
+        refreshOnDemand: async () => ({ bearer: "", expiresAt: null }),
+        refreshBaxiaToken: async () => { throw new Error("spawn failed"); },
+      },
+    });
+    // A rejecting refresh must NOT prevent the exhaustion 429 (best-effort catch):
+    await expect(
+      withPoolRetry(deps, async () => { throw new EmptyCompletionError("empty"); }),
+    ).rejects.toThrow(RateLimitError);
   });
 
   it("emptyRetryMax=0 → immediate 429 (non-stream)", async () => {
@@ -333,7 +364,15 @@ describe("withPoolRetryStream", () => {
       markSuccess: () => {},
       earliestReEnableAt: () => null,
     } as unknown as PoolLike;
-    const deps = makeDeps({ pool, config: { emptyCooldownMs: 10_000, emptyRetryMax: 3, emptyRetryGapMs: 0 } });
+    let refreshBaxiaCalled = 0;
+    const deps = makeDeps({
+      pool,
+      config: { emptyCooldownMs: 10_000, emptyRetryMax: 3, emptyRetryGapMs: 0 },
+      scheduler: {
+        refreshOnDemand: async () => ({ bearer: "", expiresAt: null }),
+        refreshBaxiaToken: async () => { refreshBaxiaCalled++; },
+      },
+    });
     let callCount = 0;
 
     async function* op(
@@ -347,6 +386,7 @@ describe("withPoolRetryStream", () => {
     const chunks = await collectChunks(withPoolRetryStream(deps, op));
     expect(callCount).toBe(4); // 1 initial + 3 retries
     expect(markEmptyCalled).toBe(1);
+    expect(refreshBaxiaCalled).toBe(1); // Baxia token rotated on exhaustion
     // Sentinel, not throw
     expect(chunks).toHaveLength(1);
     const sentinel = chunks[0];
@@ -356,6 +396,31 @@ describe("withPoolRetryStream", () => {
     } else {
       throw new Error("Expected sentinel");
     }
+  });
+
+  it("stream empty-exhaustion still yields sentinel if refresh rejects (best-effort)", async () => {
+    const pool: PoolLike = {
+      id: 0, bearer: "guest", expiresAt: null,
+      getActiveAccount: () => ({ id: 0, bearer: "guest", expiresAt: null }),
+      markEmptyAndSwitch: async () => ({ newActiveId: null, earliestReEnableAt: null }),
+      markSuccess: () => {},
+      earliestReEnableAt: () => null,
+    } as unknown as PoolLike;
+    const deps = makeDeps({
+      pool,
+      config: { emptyCooldownMs: 10_000, emptyRetryMax: 0, emptyRetryGapMs: 0 },
+      scheduler: {
+        refreshOnDemand: async () => ({ bearer: "", expiresAt: null }),
+        refreshBaxiaToken: async () => { throw new Error("spawn failed"); },
+      },
+    });
+    async function* op(): AsyncIterable<OpenAiChatChunk> {
+      yield finishChunk("stop"); // empty
+    }
+    // A rejecting refresh must NOT prevent the exhaustion sentinel (best-effort):
+    const chunks = await collectChunks(withPoolRetryStream(deps, op));
+    expect(chunks).toHaveLength(1);
+    expect("done" in chunks[0] && chunks[0].done).toBe(true);
   });
 
   it("emptyRetryMax=0 → immediate sentinel", async () => {


### PR DESCRIPTION
## Bug

After sustained burst testing, the proxy enters an unrecovered state where **every** request returns an empty completion (Baxia flag) and only a **service restart** recovers it.

## Root cause

The Baxia token (bx-ua/bx-umidtoken) is cached for **25 min** (`cacheTtlMs`). Force-refresh currently happens only in (a) `createChatSession`'s own rgv587 retry and (b) the 25-min TTL — **not** on the completion-empty path. So the pool-layer inline retry re-invokes `op` with the **cached (burned) token**; all 3 retries + every subsequent request reuse it → all empty → stuck until TTL/restart.

**Restart fixes it** because a restart = fresh Chromium session = fresh, unflagged token (same WAN IP → it's *token/session* flagging in the sustained state, not IP).

## Fix

On **empty-exhaustion**, best-effort force-refresh the Baxia token via a new optional `RetryScheduler.refreshBaxiaToken?()` hook (wired in `bin/qwen-proxy.ts` → `baxia.ensureToken({ forceRefresh: true })`). The next request (after the short cooldown) then acquires a fresh token → **recovers without a restart**, matching the observed restart-recovery behavior.

**Why exhaustion, not per-retry:**
- 1 spawn per emptying-request (not 3) — no latency hit on the transient ~2/12 volume-empties.
- Works even with `SF_QWEN_EMPTY_RETRY_MAX=0` (exhaustion fires on the first empty).
- Recovers the *next* request (like a restart), which is the actual recovery semantics.

**Safety:**
- Best-effort `try/catch` — a failed spawn is logged but never blocks the exhaustion 429/sentinel.
- `ensureToken` is single-flight → concurrent refreshes under `MAX_CONCURRENCY>1` dedupe to one Chromium spawn.

## Changes
- `src/pool/retry.ts` — `refreshBaxiaToken?()` on `RetryScheduler`; called (best-effort) in both exhaustion branches (non-stream 429 + stream sentinel).
- `bin/qwen-proxy.ts` — wires the hook to `baxia.ensureToken({ forceRefresh: true })` (where `baxia` is in scope; **not** `app.ts`, which only receives `deps.scheduler`).
- `tests/pool/retry.test.ts` — both exhaustion tests assert the token is rotated; dedicated best-effort tests (non-stream + stream) prove a rejecting refresh doesn't break the exhaustion outcome.

## Validation
- Design reviewed (REVISE → fixed wiring site + switched to on-exhaustion → APPROVED).
- Implementation reviewed (APPROVED, 2 non-blocking P3s; added the stream best-effort test to close the coverage gap).
- **381 tests green**, typecheck clean.
- `version` (0.3.0) + `CHANGELOG.md` untouched (AGENTS.md — `pnpm release` owns both → 0.3.1 patch).

## Workaround until merged/released
Restart the service when it gets stuck (or temporarily lower `SF_QWEN_BAXIA_CACHE_TTL_MS` to rotate faster — band-aid only).
