### PR TITLE
fix(qwen-proxy): /v1/models returned empty (wrong upstream shape)

### DIFF
--- a/packages/qwen-proxy/src/upstream/guest-client.ts
+++ b/packages/qwen-proxy/src/upstream/guest-client.ts
@@ -353,8 +353,8 @@ export class GuestUpstreamClient {
     const contentType = res.headers.get("content-type") ?? "";
 
     if (contentType.includes("application/json")) {
-      const json = (await res.json()) as { models?: { id: string }[] };
-      const ids = (json.models ?? []).map((m) => m.id);
+      const json = (await res.json()) as { data?: { id: string }[]; models?: { id: string }[] };
+      const ids = (json.data ?? json.models ?? []).map((m) => m.id);
       this.modelsCache = ids.map((id) => ({ id, object: "model" as const, owned_by: "qwen" }));
       return this.modelsCache;
     }

--- a/packages/qwen-proxy/tests/upstream/guest-client.test.ts
+++ b/packages/qwen-proxy/tests/upstream/guest-client.test.ts
@@ -503,12 +503,12 @@ describe("chatCompletions", () => {
 // ── listModels ────────────────────────────────────────────────────────
 
 describe("listModels", () => {
-  it("JSON path: returns models from /api/models", async () => {
+  it("JSON path: returns models from /api/models (upstream returns { data: [...] })", async () => {
     const fetcher = vi.fn().mockResolvedValue({
       ok: true,
       headers: new Headers({ "content-type": "application/json" }),
       json: async () => ({
-        models: [{ id: "qwen3-max" }, { id: "qwen3-plus" }],
+        data: [{ id: "qwen3.8-max" }, { id: "qwen3.7-plus" }],
       }),
     });
 
@@ -522,8 +522,8 @@ describe("listModels", () => {
     const models = await client.listModels("ignored");
 
     expect(models).toHaveLength(2);
-    expect(models[0]).toEqual({ id: "qwen3-max", object: "model", owned_by: "qwen" });
-    expect(models[1]).toEqual({ id: "qwen3-plus", object: "model", owned_by: "qwen" });
+    expect(models[0]).toEqual({ id: "qwen3.8-max", object: "model", owned_by: "qwen" });
+    expect(models[1]).toEqual({ id: "qwen3.7-plus", object: "model", owned_by: "qwen" });
   });
 
   it("HTML-scrape path: extracts models from prerendered data", async () => {


### PR DESCRIPTION
## Bug
`GET /v1/models` always returned `{"object":"list","data":[]}` — empty since the guest-mode refactor. Completions worked fine; only the models list was broken.

## Root cause
chat.qwen.ai's `/api/models` returns `{ "data": [{ "id": "qwen3.8-max", ... }] }`, but `listModels` parsed `json.models` (undefined) → `[]`. One-line shape mismatch.

## Fix
`guest-client.ts` — read `json.data ?? json.models ?? []` (the real `data` shape, with `models` as a legacy fallback). Test updated to the real upstream `{ data: [...] }` shape (was encoding the wrong `{ models: [...] }` shape, so it passed despite the bug).

## Validation
- 381 tests green, typecheck clean.
- Confirmed against live upstream: `curl https://chat.qwen.ai/api/models` → `{ "data": [{ "id": "qwen3.8-max", ... }] }`.
- `version` (0.3.1) + `CHANGELOG.md` untouched (AGENTS.md → `pnpm release` 0.3.2 patch).
