### PR TITLE
feat(qwen-proxy): per-proxy Baxia token-gen via local SOCKS5 bridge (fix rotation token/IP-mismatch)

### DIFF
--- a/docs-site/packages/qwen-proxy.md
+++ b/docs-site/packages/qwen-proxy.md
@@ -151,12 +151,12 @@ All configuration is via environment variables (prefix `SF_QWEN_`).
 By default the proxy egresses from a single IP. When Baxia flags that IP, every request hits the same ceiling. **Rotation mode** (`SF_QWEN_PROXY_COUNT > 1` or `SF_QWEN_PROXY_URLS`) distributes completion requests across N SOCKS5 proxies — each tried once per request (budget = N); if all N are exhausted (empty / network / 5xx), the proxy returns 429 with a cooldown. `SF_QWEN_EMPTY_RETRY_MAX` is **ignored** in rotation mode — rotation is the retry.
 
 - **Legacy (N≤1)** — single IP; `SF_QWEN_EMPTY_RETRY_MAX` inline retries + `SF_QWEN_EMPTY_COOLDOWN_MS` cooldown. Backward-compatible.
-- **Token generation stays direct** — Baxia tokens are fetched without a proxy (browser-fingerprint affinity); only `createChatSession` + the completion fetch route through the active SOCKS5.
+- **Token generation is proxy-affine** — in rotation mode, a local loopback SOCKS5 bridge injects NordVPN credentials for Chromium; tokens are cached per-proxy so the token's issuing IP matches the completion egress IP. Legacy (N≤1) generates tokens directly.
 - **Stream rotation is pre-first-content only** — once content has been streamed, no rotation (would duplicate chunks); a post-content error surfaces directly.
 - **Auto-discovery** — set `SF_QWEN_PROXY_USER` + `SF_QWEN_PROXY_PASS`; the proxy queries `api.nordvpn.com` for SOCKS5 servers, filters by `SF_QWEN_PROXY_COUNTRIES`, sorts by load, takes the N lowest-load. Explicit `SF_QWEN_PROXY_URLS` overrides discovery.
 - **Graceful degrade** — fewer-than-N servers → use what's available; 0 usable → legacy mode + warning (never fails startup).
 
-> **Empirical limitation — token/IP mismatch.** Tokens are generated on the host IP and used on rotating proxy IPs. If Qwen correlates the token's originating IP with the request IP, every proxy may empty. This ships behind the N>1 opt-in; treat the first live run as an experiment. A local SOCKS5 auth-bridge for token-gen is the planned follow-up if the mismatch triggers flagging.
+> **Per-proxy token affinity (resolved).** Token generation now egresses through the same SOCKS5 proxy as completions. A local loopback SOCKS5 bridge (`127.0.0.1` only) injects NordVPN credentials for Chromium; tokens are cached per-proxy key. The issuing IP matches the completion egress IP — no mismatch. Legacy mode (N≤1) remains unchanged.
 
 ## OpenAI API surface
 

--- a/packages/qwen-proxy/README.md
+++ b/packages/qwen-proxy/README.md
@@ -94,7 +94,7 @@ By default the proxy uses a single IP for all upstream requests. When Qwen's Bax
 
 - **Rotate triggers:** `EmptyCompletionError`, `NetworkError` (TTFB timeout, connection reset), `ServerError` (5xx), `TypeError` (fetch internals), raw `Error` (e.g. SOCKS connect failure).
 - **Terminal (no rotate):** `ClientError` (4xx, incl. `data_inspection_failed`), `RateLimitError` (429), `UnknownError`.
-- **Token generation stays direct** — Baxia tokens are fetched without a proxy (affinity with the browser fingerprint). Only `createChatSession` + the completion fetch route through SOCKS5.
+- **Token generation is proxy-affine** — in rotation mode, a local loopback SOCKS5 bridge injects NordVPN credentials for Chromium; Baxia tokens are cached per-proxy so the token's issuing IP matches the completion's egress IP. Legacy (N≤1) still generates tokens directly.
 - **Stream rotation is pre-first-content only** — once the first content token has been yielded to the client, no rotation occurs (would duplicate already-sent chunks). A post-content error surfaces directly.
 - **No `refreshBaxiaToken`** on rotation exhaustion — the token is fine; the IP ceiling is the bottleneck.
 
@@ -111,9 +111,9 @@ By default the proxy uses a single IP for all upstream requests. When Qwen's Bax
 - If discovery returns 0 usable servers (or credentials are missing), the proxy falls back to legacy mode silently.
 - If `SF_QWEN_PROXY_COUNT ≤ 1` and no explicit URLs, legacy mode applies (byte-for-byte backward-compatible).
 
-### Token/IP-mismatch empirical limitation
+### Per-proxy token affinity (resolved)
 
-Qwen may correlate the Baxia token's originating IP with the completion request IP. If the token was generated on IP A but the completion egresses through SOCKS5 IP B, upstream may reject the request. This is an empirical observation, not confirmed behavior. If it becomes a problem, the auth-bridge follow-up (token generation through the same SOCKS5 proxy) would be needed.
+Token generation now egresses through the same SOCKS5 proxy as completion requests. A pure-Node loopback SOCKS5 bridge (`net.Server` + `socks`) binds `127.0.0.1`, injects NordVPN credentials, and routes Chromium through it. Tokens are cached per-proxy key. Legacy mode (no proxy pool) remains byte-for-byte unchanged.
 
 ---
 

--- a/packages/qwen-proxy/bin/qwen-proxy.ts
+++ b/packages/qwen-proxy/bin/qwen-proxy.ts
@@ -7,6 +7,7 @@ import {
 } from "../src/index";
 import { BaxiaTokenManager } from "../src/upstream/baxia-token";
 import { GuestUpstreamClient } from "../src/upstream/guest-client";
+import { ProxyBridge } from "../src/upstream/proxy-bridge";
 import { SingleAccountPool } from "../src/pool/single";
 import { withPoolRetry } from "../src/pool/retry";
 import { withPoolRetryStream } from "../src/pool/retry";
@@ -42,28 +43,10 @@ async function main() {
       log,
     });
 
-    // Pre-warm: eagerly fetch the first token so the server starts ready
-    if (config.baxia.preWarm) {
-      try {
-        await baxia.ensureToken();
-        log.info("baxia pre-warm succeeded");
-      } catch (e) {
-        log.error("baxia pre-warm failed", { error: String(e) });
-        process.exit(1);
-      }
-    }
-
-    // Start background refresh loop
-    baxia.startRefreshLoop();
-
-    // Cap concurrent chat.qwen.ai calls — Baxia flags the IP on concurrent
-    // upstream connections. Default 1 (serialize, like the web chat); tune with SF_QWEN_MAX_CONCURRENCY.
-    const concurrency = new Semaphore(config.maxConcurrency);
-    const client = new GuestUpstreamClient({ baxia, chatUrl: CHAT_URL, concurrency, log, proxyDispatcherCache: undefined, timeoutMs: config.timeoutMs });
-
     // Proxy pool rotation (NordVPN SOCKS5)
     let proxyPool;
     let proxyDispatcherCache;
+    let bridge: ProxyBridge | undefined;
     if (config.proxyCount > 1 || config.proxyUrlsRaw.trim()) {
       proxyPool = await createProxyPool({
         proxyCount: config.proxyCount,
@@ -76,12 +59,37 @@ async function main() {
       });
       if (proxyPool.size > 0) {
         proxyDispatcherCache = new ProxyDispatcherCache();
+        // S-M2-2: start loopback SOCKS5 bridge for proxy-affine token gen
+        bridge = new ProxyBridge({ log });
+        await bridge.start();
+        baxia.setBridge(bridge);
+        log.info("proxy-affine bridge started", { port: bridge.getPort() });
         log.info("proxy rotation enabled", { size: proxyPool.size });
       } else {
         proxyPool = undefined;
         log.warn("proxy pool empty — legacy");
       }
     }
+
+    // Pre-warm: eagerly fetch the first token so the server starts ready
+    // (S-M2-2: after bridge setup so token-gen egresses through the bridge)
+    if (config.baxia.preWarm) {
+      try {
+        await baxia.ensureToken();
+        log.info("baxia pre-warm succeeded");
+      } catch (e) {
+        log.error("baxia pre-warm failed", { error: String(e) });
+        process.exit(1);
+      }
+    }
+
+    // Start background refresh loop (S-M2-2: no-op when bridge set — lazy per-proxy)
+    baxia.startRefreshLoop();
+
+    // Cap concurrent chat.qwen.ai calls — Baxia flags the IP on concurrent
+    // upstream connections. Default 1 (serialize, like the web chat); tune with SF_QWEN_MAX_CONCURRENCY.
+    const concurrency = new Semaphore(config.maxConcurrency);
+    const client = new GuestUpstreamClient({ baxia, chatUrl: CHAT_URL, concurrency, log, proxyDispatcherCache, timeoutMs: config.timeoutMs });
 
     // Re-create client with proxy dispatcher cache + timeout if rotation enabled
     const finalClient = proxyDispatcherCache
@@ -127,11 +135,12 @@ async function main() {
 
     log.info("qwen-proxy started", { port: handle.port });
 
-    // Graceful shutdown: baxia refresh → server → db
-    const shutdown = () => {
+    // Graceful shutdown: drain HTTP → baxia → bridge → db
+    const shutdown = async () => {
       log.info("shutting down");
-      baxia.stop();
       handle.close();
+      baxia.stop();
+      if (bridge) await bridge.stop();
       db.close();
       process.exit(0);
     };

--- a/packages/qwen-proxy/bin/qwen-proxy.ts
+++ b/packages/qwen-proxy/bin/qwen-proxy.ts
@@ -71,9 +71,11 @@ async function main() {
       }
     }
 
-    // Pre-warm: eagerly fetch the first token so the server starts ready
-    // (S-M2-2: after bridge setup so token-gen egresses through the bridge)
-    if (config.baxia.preWarm) {
+    // Pre-warm: eagerly fetch the first token so the server starts ready.
+    // In rotation mode (bridge set), skip pre-warm — the lazy on-demand refresh
+    // handles the first proxy's token when the first request arrives. Pre-warming
+    // with no proxy would mint a DIRECT_KEY token via direct Chromium (wasteful).
+    if (config.baxia.preWarm && !bridge) {
       try {
         await baxia.ensureToken();
         log.info("baxia pre-warm succeeded");

--- a/packages/qwen-proxy/bin/qwen-proxy.ts
+++ b/packages/qwen-proxy/bin/qwen-proxy.ts
@@ -11,7 +11,7 @@ import { ProxyBridge } from "../src/upstream/proxy-bridge";
 import { SingleAccountPool } from "../src/pool/single";
 import { withPoolRetry } from "../src/pool/retry";
 import { withPoolRetryStream } from "../src/pool/retry";
-import { createProxyPool, ProxyDispatcherCache } from "../src/pool/proxy-pool";
+import { createProxyPool, ProxyDispatcherCache, ProxyPool } from "../src/pool/proxy-pool";
 import { RequestThrottle } from "../src/pool/throttle";
 import { Semaphore } from "../src/pool/semaphore";
 import type { AppDeps } from "../src/server/app";
@@ -44,7 +44,7 @@ async function main() {
     });
 
     // Proxy pool rotation (NordVPN SOCKS5)
-    let proxyPool;
+    let proxyPool: ProxyPool | undefined;
     let proxyDispatcherCache;
     let bridge: ProxyBridge | undefined;
     if (config.proxyCount > 1 || config.proxyUrlsRaw.trim()) {
@@ -106,7 +106,13 @@ async function main() {
       refreshOnDemand: async () => ({ bearer: "guest", expiresAt: null }),
       // Rotate the Baxia token on empty-exhaustion: in guest mode the token/session
       // can get flagged by Baxia, and a fresh Chromium spawn recovers it without a restart.
-      refreshBaxiaToken: async () => { await baxia.ensureToken({ forceRefresh: true }); },
+      // When a proxyPool exists, thread the active proxy so the refresh targets
+      // the proxy's cache entry (not DIRECT_KEY). Without this, size===1 proxy setups
+      // would refresh direct-Chromium's token instead of the proxy's → stale token.
+      refreshBaxiaToken: async () => {
+        const proxy = proxyPool?.getActive();
+        await baxia.ensureToken({ forceRefresh: true, ...(proxy ? { proxy } : {}) });
+      },
     };
 
     // Per-account request throttle (look-human): paces dispatches to reduce

--- a/packages/qwen-proxy/package.json
+++ b/packages/qwen-proxy/package.json
@@ -36,6 +36,7 @@
     "@pi-stef/paths": "^0.3.0",
     "better-sqlite3": "^12.11.1",
     "hono": "^4.6.0",
+    "socks": "^2.8.9",
     "socks-proxy-agent": "^10.1.0",
     "tsx": "^4.0.0",
     "zod": "^3.23.0"

--- a/packages/qwen-proxy/src/index.ts
+++ b/packages/qwen-proxy/src/index.ts
@@ -18,3 +18,4 @@ export { translateQwenSse, mapUsageToOpenAI, isDataInspectionFailed } from "./up
 export { SingleAccountPool, type SingleAccountPoolDeps } from "./pool/single";
 export { type PoolLike } from "./pool/types";
 export * from "./pool";
+export { parseSocksUrl, type ParsedSocksUrl } from "./upstream/proxy-bridge";

--- a/packages/qwen-proxy/src/index.ts
+++ b/packages/qwen-proxy/src/index.ts
@@ -18,4 +18,4 @@ export { translateQwenSse, mapUsageToOpenAI, isDataInspectionFailed } from "./up
 export { SingleAccountPool, type SingleAccountPoolDeps } from "./pool/single";
 export { type PoolLike } from "./pool/types";
 export * from "./pool";
-export { parseSocksUrl, type ParsedSocksUrl } from "./upstream/proxy-bridge";
+export { parseSocksUrl, type ParsedSocksUrl, ProxyBridge, type ProxyBridgeConfig } from "./upstream/proxy-bridge";

--- a/packages/qwen-proxy/src/pool/proxy-pool.ts
+++ b/packages/qwen-proxy/src/pool/proxy-pool.ts
@@ -24,7 +24,11 @@ export function normalizeSocksUrl(
   // Default port to 1080
   if (!url.port) url.port = "1080";
 
-  // Determine creds: URL creds take priority, fall back to global
+  // Determine creds: URL creds take priority, fall back to global.
+  // url.username/password are already percent-encoded by WHATWG URL;
+  // globalUser/globalPass are plain strings that need encoding.
+  const userFromUrl = !!url.username;
+  const passFromUrl = !!url.password;
   const user = url.username || globalUser;
   const pass = url.password || globalPass;
 
@@ -32,7 +36,9 @@ export function normalizeSocksUrl(
   if (!user || !pass) return null;
 
   // Rebuild with creds and port
-  return `${url.protocol}//${encodeURIComponent(user)}:${encodeURIComponent(pass)}@${url.hostname}:${url.port}`;
+  const encUser = userFromUrl ? user : encodeURIComponent(user);
+  const encPass = passFromUrl ? pass : encodeURIComponent(pass);
+  return `${url.protocol}//${encUser}:${encPass}@${url.hostname}:${url.port}`;
 }
 
 // ── parseProxyUrls ──────────────────────────────────────────────────────────

--- a/packages/qwen-proxy/src/upstream/baxia-token.ts
+++ b/packages/qwen-proxy/src/upstream/baxia-token.ts
@@ -28,6 +28,8 @@ export interface BaxiaTokenManagerConfig {
   fallback: boolean;
   userAgent: string;
   log: Logger;
+  /** Optional bridge for proxy-affine token generation (S-M1-7). */
+  bridge?: { getPort(): number; setUpstream(key: string): void };
   now?: () => number;
   spawn?: typeof import("node:child_process").spawn;
   WebSocketCtor?: typeof WebSocket;
@@ -90,6 +92,8 @@ export class BaxiaTokenManager {
   private static readonly DIRECT_KEY = "";
   // Global spawn mutex — serializes all doRefresh calls
   private spawnChain: Promise<void> = Promise.resolve();
+  // Optional bridge for proxy-affine token generation (S-M1-7)
+  private bridge?: { getPort(): number; setUpstream(key: string): void };
 
   constructor(config: BaxiaTokenManagerConfig) {
     this.config = config;
@@ -97,6 +101,12 @@ export class BaxiaTokenManager {
     this._WebSocketCtor = config.WebSocketCtor ?? (globalThis as any).WebSocket;
     this._fetcher = config.fetcher ?? globalThis.fetch;
     this._sleep = config.sleep ?? ((ms) => new Promise((r) => setTimeout(r, ms)));
+    this.bridge = config.bridge;
+  }
+
+  /** Set the bridge for proxy-affine token generation (S-M1-7 / S-M2-2). */
+  setBridge(bridge: { getPort(): number; setUpstream(key: string): void }): void {
+    this.bridge = bridge;
   }
 
   /** Expose resolved spawn fn for P0 regression testing. */
@@ -132,7 +142,7 @@ export class BaxiaTokenManager {
 
   // ── startChrome ─────────────────────────────────────────────────────────
 
-  private startChrome(exe: string): { child: any; port: number } {
+  private startChrome(exe: string, proxyServerUrl?: string): { child: any; port: number } {
     const port = randomPort(9400, 9999);
     const userDataDir = fs.mkdtempSync(
       path.join(os.tmpdir(), "baxia-chrome-"),
@@ -149,6 +159,11 @@ export class BaxiaTokenManager {
       `--user-agent=${this.config.userAgent}`,
       "about:blank",
     ];
+    // S-M1-7: inject proxy-server + DNS pinning for proxy-affine token gen
+    if (proxyServerUrl) {
+      args.unshift(`--proxy-server=${proxyServerUrl}`);
+      args.unshift("--host-resolver-rules=MAP * ~NOTFOUND, EXCLUDE 127.0.0.1");
+    }
     const child = this._spawn(exe, args, { stdio: "ignore" });
     return { child, port };
   }
@@ -235,9 +250,13 @@ export class BaxiaTokenManager {
 
   // ── getBaxiaTokens ──────────────────────────────────────────────────────
 
-  private async getBaxiaTokens(): Promise<BaxiaTokens> {
+  private async getBaxiaTokens(proxy?: string): Promise<BaxiaTokens> {
     const exe = this.findChrome();
-    const { child, port } = this.startChrome(exe);
+    // S-M1-7: compute loopback SOCKS5 URL for proxy-affine token gen
+    const proxyServerUrl = (proxy && this.bridge)
+      ? `socks5://127.0.0.1:${this.bridge.getPort()}`
+      : undefined;
+    const { child, port } = this.startChrome(exe, proxyServerUrl);
 
     try {
       // Wait for Chrome to start /json/list endpoint
@@ -397,10 +416,15 @@ export class BaxiaTokenManager {
   }
 
   private async doRefresh(key: string): Promise<BaxiaTokens> {
+    const proxy = key !== BaxiaTokenManager.DIRECT_KEY ? key : undefined;
     return this.withSpawnLock(async () => {
     const start = this.config.now?.() ?? Date.now();
     try {
-      const tokens = await this.getBaxiaTokens();
+      // S-M1-7: set upstream proxy on bridge before spawning Chrome
+      if (proxy && this.bridge) {
+        this.bridge.setUpstream(proxy);
+      }
+      const tokens = await this.getBaxiaTokens(proxy);
       this.proxyCache.set(key, {
         tokens,
         cachedAt: this.config.now?.() ?? Date.now(),
@@ -426,6 +450,8 @@ export class BaxiaTokenManager {
   }
 
   startRefreshLoop(): void {
+    // S-M1-7: bridge mode uses lazy per-proxy refresh (no periodic loop)
+    if (this.bridge) return;
     if (this.refreshTimer) return; // idempotent
     const interval = Math.max(60_000, this.config.cacheTtlMs - 120_000);
     this.refreshTimer = setInterval(() => {

--- a/packages/qwen-proxy/src/upstream/baxia-token.ts
+++ b/packages/qwen-proxy/src/upstream/baxia-token.ts
@@ -88,6 +88,8 @@ export class BaxiaTokenManager {
   private lastUsedProxy: string = "";
   private refreshTimer: ReturnType<typeof setInterval> | null = null;
   private static readonly DIRECT_KEY = "";
+  // Global spawn mutex — serializes all doRefresh calls
+  private spawnChain: Promise<void> = Promise.resolve();
 
   constructor(config: BaxiaTokenManagerConfig) {
     this.config = config;
@@ -386,7 +388,16 @@ export class BaxiaTokenManager {
     }
   }
 
+  private async withSpawnLock<T>(fn: () => Promise<T>): Promise<T> {
+    // Chain onto spawnChain so new spawns wait for the previous one to settle
+    const chained = this.spawnChain.then(fn, fn);
+    // Re-chain the settled promise (never rejects — fn is called for both resolve/reject)
+    this.spawnChain = chained.then(() => {}, () => {});
+    return chained;
+  }
+
   private async doRefresh(key: string): Promise<BaxiaTokens> {
+    return this.withSpawnLock(async () => {
     const start = this.config.now?.() ?? Date.now();
     try {
       const tokens = await this.getBaxiaTokens();
@@ -411,6 +422,7 @@ export class BaxiaTokenManager {
       }
       throw e;
     }
+    });
   }
 
   startRefreshLoop(): void {

--- a/packages/qwen-proxy/src/upstream/baxia-token.ts
+++ b/packages/qwen-proxy/src/upstream/baxia-token.ts
@@ -83,12 +83,11 @@ export class BaxiaTokenManager {
   private _sleep: (ms: number) => Promise<void>;
 
   // Orchestration state
-  private cached: BaxiaTokens | null = null;
-  private cachedAt = 0;
-  private pending: Promise<BaxiaTokens> | null = null;
+  private proxyCache = new Map<string, { tokens: BaxiaTokens | null; cachedAt: number; lastSpawnDurationMs: number | null; consecutiveFailures: number }>();
+  private pendingByProxy = new Map<string, Promise<BaxiaTokens>>();
+  private lastUsedProxy: string = "";
   private refreshTimer: ReturnType<typeof setInterval> | null = null;
-  private consecutiveFailures = 0;
-  private lastSpawnDurationMs: number | null = null;
+  private static readonly DIRECT_KEY = "";
 
   constructor(config: BaxiaTokenManagerConfig) {
     this.config = config;
@@ -355,49 +354,60 @@ export class BaxiaTokenManager {
     }
   }
 
-  // ── Orchestration (S-M1-4) ───────────────────────────────────────────
+  // ── Orchestration (S-M1-5 per-proxy cache) ──────────────────────────
 
   async ensureToken(
-    opts?: { forceRefresh?: boolean },
+    opts?: { forceRefresh?: boolean; proxy?: string },
   ): Promise<BaxiaTokens> {
+    const key = opts?.proxy ?? BaxiaTokenManager.DIRECT_KEY;
     const now = this.config.now?.() ?? Date.now();
+    const entry = this.proxyCache.get(key);
 
-    // Cache hit
+    // Cache hit (lazy TTL per key)
     if (
       !opts?.forceRefresh &&
-      this.cached &&
-      now - this.cachedAt < this.config.cacheTtlMs
+      entry?.tokens &&
+      now - entry.cachedAt < this.config.cacheTtlMs
     ) {
-      return this.cached;
+      return entry.tokens;
     }
 
-    // Single-flight: if a refresh is already in-flight, piggyback on it
-    if (this.pending) return this.pending;
+    // Single-flight: if a refresh is already in-flight for this proxy, piggyback
+    const existing = this.pendingByProxy.get(key);
+    if (existing) return existing;
 
     // Start a new refresh (assigned synchronously before any await)
-    this.pending = this.doRefresh(now);
+    const p = this.doRefresh(key);
+    this.pendingByProxy.set(key, p);
     try {
-      return await this.pending;
+      return await p;
     } finally {
-      this.pending = null;
+      this.pendingByProxy.delete(key);
     }
   }
 
-  private async doRefresh(now: number): Promise<BaxiaTokens> {
-    const start = now;
+  private async doRefresh(key: string): Promise<BaxiaTokens> {
+    const start = this.config.now?.() ?? Date.now();
     try {
       const tokens = await this.getBaxiaTokens();
-      this.cached = tokens;
-      this.cachedAt = this.config.now?.() ?? Date.now(); // P3: set after token obtained
-      this.consecutiveFailures = 0;
-      this.lastSpawnDurationMs =
-        (this.config.now?.() ?? Date.now()) - start;
+      this.proxyCache.set(key, {
+        tokens,
+        cachedAt: this.config.now?.() ?? Date.now(),
+        lastSpawnDurationMs: (this.config.now?.() ?? Date.now()) - start,
+        consecutiveFailures: 0,
+      });
+      this.lastUsedProxy = key; // SUCCESS only
       return tokens;
     } catch (e) {
-      this.consecutiveFailures++;
-      if (this.config.fallback) {
-        // Return stale cache if available, otherwise rethrow
-        if (this.cached) return this.cached;
+      const prev = this.proxyCache.get(key);
+      this.proxyCache.set(key, {
+        tokens: prev?.tokens ?? null,
+        cachedAt: prev?.cachedAt ?? 0,
+        lastSpawnDurationMs: prev?.lastSpawnDurationMs ?? null,
+        consecutiveFailures: (prev?.consecutiveFailures ?? 0) + 1,
+      });
+      if (this.config.fallback && prev?.tokens) {
+        return prev.tokens;
       }
       throw e;
     }
@@ -420,18 +430,39 @@ export class BaxiaTokenManager {
   }
 
   status(): BaxiaStatus {
+    const key = this.lastUsedProxy ?? BaxiaTokenManager.DIRECT_KEY;
+    const entry = this.proxyCache.get(key);
     const now = this.config.now?.() ?? Date.now();
     return {
-      cached: this.cached !== null,
-      cachedAt: this.cached ? this.cachedAt : null,
-      ageMs: this.cached ? now - this.cachedAt : null,
+      cached: entry?.tokens != null,
+      cachedAt: entry?.cachedAt ?? null,
+      ageMs: entry ? now - entry.cachedAt : null,
       ttlMs: this.config.cacheTtlMs,
       nextRefreshInMs: this.refreshTimer
         ? Math.max(60_000, this.config.cacheTtlMs - 120_000)
         : null,
-      lastSpawnDurationMs: this.lastSpawnDurationMs,
-      consecutiveFailures: this.consecutiveFailures,
+      lastSpawnDurationMs: entry?.lastSpawnDurationMs ?? null,
+      consecutiveFailures: entry?.consecutiveFailures ?? 0,
     };
+  }
+
+  proxyStatuses(): Record<string, BaxiaStatus> {
+    const now = this.config.now?.() ?? Date.now();
+    const result: Record<string, BaxiaStatus> = {};
+    for (const [key, entry] of this.proxyCache) {
+      result[key] = {
+        cached: entry.tokens != null,
+        cachedAt: entry.cachedAt,
+        ageMs: now - entry.cachedAt,
+        ttlMs: this.config.cacheTtlMs,
+        nextRefreshInMs: this.refreshTimer
+          ? Math.max(60_000, this.config.cacheTtlMs - 120_000)
+          : null,
+        lastSpawnDurationMs: entry.lastSpawnDurationMs,
+        consecutiveFailures: entry.consecutiveFailures,
+      };
+    }
+    return result;
   }
 }
 

--- a/packages/qwen-proxy/src/upstream/baxia-token.ts
+++ b/packages/qwen-proxy/src/upstream/baxia-token.ts
@@ -85,7 +85,7 @@ export class BaxiaTokenManager {
   private _sleep: (ms: number) => Promise<void>;
 
   // Orchestration state
-  private proxyCache = new Map<string, { tokens: BaxiaTokens | null; cachedAt: number; lastSpawnDurationMs: number | null; consecutiveFailures: number }>();
+  private proxyCache = new Map<string, { tokens: BaxiaTokens | null; cachedAt: number | null; lastSpawnDurationMs: number | null; consecutiveFailures: number }>();
   private pendingByProxy = new Map<string, Promise<BaxiaTokens>>();
   private lastUsedProxy: string = "";
   private refreshTimer: ReturnType<typeof setInterval> | null = null;
@@ -388,6 +388,7 @@ export class BaxiaTokenManager {
     if (
       !opts?.forceRefresh &&
       entry?.tokens &&
+      entry.cachedAt != null &&
       now - entry.cachedAt < this.config.cacheTtlMs
     ) {
       return entry.tokens;
@@ -437,7 +438,7 @@ export class BaxiaTokenManager {
       const prev = this.proxyCache.get(key);
       this.proxyCache.set(key, {
         tokens: prev?.tokens ?? null,
-        cachedAt: prev?.cachedAt ?? 0,
+        cachedAt: prev?.cachedAt ?? null,
         lastSpawnDurationMs: prev?.lastSpawnDurationMs ?? null,
         consecutiveFailures: (prev?.consecutiveFailures ?? 0) + 1,
       });
@@ -474,7 +475,7 @@ export class BaxiaTokenManager {
     return {
       cached: entry?.tokens != null,
       cachedAt: entry?.cachedAt ?? null,
-      ageMs: entry ? now - entry.cachedAt : null,
+      ageMs: entry?.cachedAt != null ? now - entry.cachedAt : null,
       ttlMs: this.config.cacheTtlMs,
       nextRefreshInMs: this.refreshTimer
         ? Math.max(60_000, this.config.cacheTtlMs - 120_000)
@@ -491,7 +492,7 @@ export class BaxiaTokenManager {
       result[key] = {
         cached: entry.tokens != null,
         cachedAt: entry.cachedAt,
-        ageMs: now - entry.cachedAt,
+        ageMs: entry.cachedAt != null ? now - entry.cachedAt : null,
         ttlMs: this.config.cacheTtlMs,
         nextRefreshInMs: this.refreshTimer
           ? Math.max(60_000, this.config.cacheTtlMs - 120_000)

--- a/packages/qwen-proxy/src/upstream/guest-client.ts
+++ b/packages/qwen-proxy/src/upstream/guest-client.ts
@@ -106,7 +106,7 @@ export class GuestUpstreamClient {
 
     const maxRetries = 3;
     for (let attempt = 0; attempt < maxRetries; attempt++) {
-      const tokens = await this.baxia.ensureToken(attempt > 0 ? { forceRefresh: true } : undefined);
+      const tokens = await this.baxia.ensureToken(attempt > 0 ? { forceRefresh: true, proxy } : { proxy });
       const headers: Record<string, string> = {
         Accept: "application/json",
         "Content-Type": "application/json",
@@ -311,7 +311,7 @@ export class GuestUpstreamClient {
     const chatType: "t2t" | "search" = wantsSearch ? "search" : "t2t";
 
     const chatId = await this.createChatSession(body.model, chatType, proxy);
-    const tokens = await this.baxia.ensureToken();
+    const tokens = await this.baxia.ensureToken({ proxy });
 
     const qwenMsg = this.normalizeMessages(
       body.messages,

--- a/packages/qwen-proxy/src/upstream/proxy-bridge.ts
+++ b/packages/qwen-proxy/src/upstream/proxy-bridge.ts
@@ -1,0 +1,36 @@
+/**
+ * ProxyBridge — local SOCKS5-no-auth loopback server that injects upstream
+ * NordVPN SOCKS5 credentials.  Per-proxy Baxia token affinity.
+ */
+
+// ── parseSocksUrl ───────────────────────────────────────────────────────────
+
+export interface ParsedSocksUrl {
+  host: string;
+  port: number;
+  user: string;
+  pass: string;
+}
+
+/**
+ * Parse a `socks5://user:pass@host:port` or `socks5h://…` URL.
+ * @throws on missing host, missing credentials, or unsupported protocol.
+ */
+export function parseSocksUrl(key: string): ParsedSocksUrl {
+  const url = new URL(key);
+  if (url.protocol !== "socks5:" && url.protocol !== "socks5h:") {
+    throw new Error(`parseSocksUrl: unsupported protocol "${url.protocol}" (expected socks5: or socks5h:)`);
+  }
+  if (!url.hostname) {
+    throw new Error(`parseSocksUrl: missing host in "${key}"`);
+  }
+  if (!url.username || !url.password) {
+    throw new Error(`parseSocksUrl: missing credentials (user:pass) in "${key}"`);
+  }
+  return {
+    host: url.hostname,
+    port: url.port ? Number(url.port) : 1080,
+    user: decodeURIComponent(url.username),
+    pass: decodeURIComponent(url.password),
+  };
+}

--- a/packages/qwen-proxy/src/upstream/proxy-bridge.ts
+++ b/packages/qwen-proxy/src/upstream/proxy-bridge.ts
@@ -223,13 +223,17 @@ export class ProxyBridge {
     a.pipe(b);
     b.pipe(a);
     let done = false;
-    const onError = () => {
+    const onDone = () => {
       if (done) return;
       done = true;
       a.destroy();
       b.destroy();
     };
-    a.on("error", onError);
-    b.on("error", onError);
+    a.on("error", onDone);
+    b.on("error", onDone);
+    // Also handle 'close' — e.g. Chromium SIGKILL emits 'close' not 'error'.
+    // Without this, the upstream 'remote' socket lingers until SOCKS5 keep-alive timeout.
+    a.once("close", () => b.destroy());
+    b.once("close", () => a.destroy());
   }
 }

--- a/packages/qwen-proxy/src/upstream/proxy-bridge.ts
+++ b/packages/qwen-proxy/src/upstream/proxy-bridge.ts
@@ -175,10 +175,60 @@ export class ProxyBridge {
       const port = (await readN(2)).readUInt16BE(0);
 
       // Phase 3: Forward via upstream (S-M1-4)
-      void host; void port; void this.socksClient; void this.log;
-      socket.destroy();
+      await this.handleConnect(socket, host, port);
     } catch {
       socket.destroy();
     }
+  }
+
+  private async handleConnect(client: net.Socket, host: string, port: number): Promise<void> {
+    const VER = 0x05, REP_GENERAL_FAILURE = 0x01;
+    const rep = (code: number) => client.write(Buffer.from([VER, code, 0x00, 0x01, 0, 0, 0, 0, 0, 0]));
+
+    // Read upstream at CONNECT time (swap-safe)
+    const upstream = this.currentUpstream;
+    if (!upstream) {
+      this.log.warn("ProxyBridge: no upstream set, rejecting CONNECT");
+      rep(REP_GENERAL_FAILURE);
+      client.end();
+      return;
+    }
+
+    try {
+      const { socket: remote } = await this.socksClient.createConnection({
+        command: "connect",
+        destination: { host, port },
+        proxy: {
+          host: upstream.host,
+          port: upstream.port,
+          type: 5,
+          userId: upstream.user,
+          password: upstream.pass,
+        },
+        timeout: 10_000,
+      });
+
+      // Success reply: BND.ADDR = 127.0.0.1:0 (placeholder)
+      client.write(Buffer.from([VER, 0x00, 0x00, 0x01, 127, 0, 0, 1, 0, 0]));
+      this.pipeBoth(client, remote);
+    } catch (err) {
+      this.log.warn("ProxyBridge: upstream connect failed", { error: String(err), host, port });
+      rep(REP_GENERAL_FAILURE);
+      client.end();
+    }
+  }
+
+  private pipeBoth(a: net.Socket, b: net.Socket): void {
+    a.pipe(b);
+    b.pipe(a);
+    let done = false;
+    const onError = () => {
+      if (done) return;
+      done = true;
+      a.destroy();
+      b.destroy();
+    };
+    a.on("error", onError);
+    b.on("error", onError);
   }
 }

--- a/packages/qwen-proxy/src/upstream/proxy-bridge.ts
+++ b/packages/qwen-proxy/src/upstream/proxy-bridge.ts
@@ -3,6 +3,9 @@
  * NordVPN SOCKS5 credentials.  Per-proxy Baxia token affinity.
  */
 
+import * as net from "node:net";
+import type { Logger } from "../server/logger";
+
 // ── parseSocksUrl ───────────────────────────────────────────────────────────
 
 export interface ParsedSocksUrl {
@@ -33,4 +36,99 @@ export function parseSocksUrl(key: string): ParsedSocksUrl {
     user: decodeURIComponent(url.username),
     pass: decodeURIComponent(url.password),
   };
+}
+
+// ── ProxyBridge ─────────────────────────────────────────────────────────────
+
+export interface ProxyBridgeConfig {
+  log: Logger;
+  socksClient?: typeof import("socks").SocksClient;
+}
+
+/**
+ * Local SOCKS5-no-auth loopback bridge.
+ * Chromium connects to 127.0.0.1:<port>, the bridge reads the SOCKS5
+ * CONNECT request, then forwards the connection through the upstream
+ * SOCKS5 proxy with injected credentials.
+ */
+export class ProxyBridge {
+  private server: net.Server | null = null;
+  private port: number | null = null;
+  private currentUpstream: ParsedSocksUrl | null = null;
+  private readonly log: Logger;
+  private readonly socksClient: typeof import("socks").SocksClient;
+
+  constructor(config: ProxyBridgeConfig) {
+    this.log = config.log;
+    this.socksClient = (config.socksClient ?? (require("socks") as typeof import("socks")).SocksClient) as typeof import("socks").SocksClient;
+  }
+
+  /**
+   * Start the loopback SOCKS5 server on 127.0.0.1.
+   * @returns the assigned port
+   */
+  async start(): Promise<number> {
+    if (this.server) return this.port!;
+    return new Promise<number>((resolve, reject) => {
+      const server = net.createServer();
+      server.on("connection", (socket) => this.handleConnection(socket));
+      server.on("error", reject);
+      server.listen(0, "127.0.0.1", () => {
+        this.server = server;
+        this.port = (server.address() as net.AddressInfo).port;
+        resolve(this.port);
+      });
+    });
+  }
+
+  /**
+   * Stop the server.  Idempotent.
+   */
+  async stop(): Promise<void> {
+    if (!this.server) return;
+    const srv = this.server;
+    this.server = null;
+    this.port = null;
+    return new Promise<void>((resolve) => srv.close(() => resolve()));
+  }
+
+  /**
+   * Get the port.  Throws if not started.
+   */
+  getPort(): number {
+    if (this.port === null) throw new Error("ProxyBridge: not started");
+    return this.port;
+  }
+
+  /**
+   * Whether the server is listening.
+   */
+  isStarted(): boolean {
+    return this.server !== null;
+  }
+
+  /**
+   * Set the current upstream proxy (parsed from socks5 URL).
+   */
+  setUpstream(key: string): void {
+    this.currentUpstream = parseSocksUrl(key);
+  }
+
+  /**
+   * Get the current upstream proxy (null if not set).
+   */
+  getCurrentUpstream(): ParsedSocksUrl | null {
+    return this.currentUpstream;
+  }
+
+  /**
+   * Handle a new connection from Chromium.
+   * (Stub — will be implemented in S-M1-3/S-M1-4.)
+   */
+  private handleConnection(socket: net.Socket): void {
+    // Stub: destroy immediately until handshake logic is added in S-M1-3
+    void this.socksClient; // will be used in S-M1-4 forwarding
+    void this.log; // will be used in S-M1-3 handshake
+    socket.destroy();
+  }
 }

--- a/packages/qwen-proxy/src/upstream/proxy-bridge.ts
+++ b/packages/qwen-proxy/src/upstream/proxy-bridge.ts
@@ -4,6 +4,7 @@
  */
 
 import * as net from "node:net";
+import { SocksClient } from "socks";
 import type { Logger } from "../server/logger";
 
 // ── parseSocksUrl ───────────────────────────────────────────────────────────
@@ -42,7 +43,7 @@ export function parseSocksUrl(key: string): ParsedSocksUrl {
 
 export interface ProxyBridgeConfig {
   log: Logger;
-  socksClient?: typeof import("socks").SocksClient;
+  socksClient?: typeof SocksClient;
 }
 
 /**
@@ -56,11 +57,11 @@ export class ProxyBridge {
   private port: number | null = null;
   private currentUpstream: ParsedSocksUrl | null = null;
   private readonly log: Logger;
-  private readonly socksClient: typeof import("socks").SocksClient;
+  private readonly socksClient: typeof SocksClient;
 
   constructor(config: ProxyBridgeConfig) {
     this.log = config.log;
-    this.socksClient = (config.socksClient ?? (require("socks") as typeof import("socks")).SocksClient) as typeof import("socks").SocksClient;
+    this.socksClient = config.socksClient ?? SocksClient;
   }
 
   /**

--- a/packages/qwen-proxy/src/upstream/proxy-bridge.ts
+++ b/packages/qwen-proxy/src/upstream/proxy-bridge.ts
@@ -124,7 +124,7 @@ export class ProxyBridge {
 
   /**
    * Handle a new connection from Chromium.
-   * (Stub — will be implemented in S-M1-3/S-M1-4.)
+   * (SOCKS5 handshake + forwarding — implemented in S-M1-3/S-M1-4.)
    */
   private async handleConnection(socket: net.Socket): Promise<void> {
     const VER = 0x05, AUTH_NONE = 0x00, AUTH_NO_ACCEPTABLE = 0xFF;

--- a/packages/qwen-proxy/src/upstream/proxy-bridge.ts
+++ b/packages/qwen-proxy/src/upstream/proxy-bridge.ts
@@ -125,10 +125,60 @@ export class ProxyBridge {
    * Handle a new connection from Chromium.
    * (Stub — will be implemented in S-M1-3/S-M1-4.)
    */
-  private handleConnection(socket: net.Socket): void {
-    // Stub: destroy immediately until handshake logic is added in S-M1-3
-    void this.socksClient; // will be used in S-M1-4 forwarding
-    void this.log; // will be used in S-M1-3 handshake
-    socket.destroy();
+  private async handleConnection(socket: net.Socket): Promise<void> {
+    const VER = 0x05, AUTH_NONE = 0x00, AUTH_NO_ACCEPTABLE = 0xFF;
+    const CMD_CONNECT = 0x01, REP_CMD_NOT_SUPPORTED = 0x07, REP_ATYP_NOT_SUPPORTED = 0x08;
+    const ATYP_IPV4 = 0x01, ATYP_DOMAIN = 0x03, ATYP_IPV6 = 0x04;
+
+    let excess = Buffer.alloc(0);
+    const readN = async (n: number): Promise<Buffer> => {
+      if (excess.length >= n) { const r = excess.subarray(0, n); excess = excess.subarray(n); return r; }
+      return new Promise((resolve, reject) => {
+        let buf = excess; excess = Buffer.alloc(0);
+        const onData = (chunk: Buffer) => {
+          buf = Buffer.concat([buf, chunk]);
+          if (buf.length >= n) { off(); excess = buf.subarray(n); resolve(buf.subarray(0, n)); }
+        };
+        const off = () => { socket.off("data", onData); socket.off("close", onEnd); socket.off("error", onEnd); };
+        const onEnd = (e?: Error) => { off(); reject(e ?? new Error("socket closed during readN")); };
+        socket.on("data", onData); socket.once("close", onEnd); socket.once("error", onEnd);
+      });
+    };
+
+    const rep = (code: number) => socket.write(Buffer.from([VER, code, 0x00, 0x01, 0, 0, 0, 0, 0, 0]));
+
+    try {
+      // Phase 1: Method negotiation
+      const head = await readN(2);
+      if (head[0] !== VER) { socket.destroy(); return; }
+      const methods = await readN(head[1]);
+      if (!methods.includes(AUTH_NONE)) { rep(AUTH_NO_ACCEPTABLE); socket.end(); return; }
+      socket.write(Buffer.from([VER, AUTH_NONE]));
+
+      // Phase 2: CONNECT request
+      const req = await readN(4);
+      if (req[0] !== VER) { socket.destroy(); return; }
+      if (req[1] !== CMD_CONNECT) { rep(REP_CMD_NOT_SUPPORTED); socket.end(); return; }
+      let host: string;
+      const atyp = req[3];
+      if (atyp === ATYP_IPV4) {
+        host = Array.from(await readN(4)).join(".");
+      } else if (atyp === ATYP_DOMAIN) {
+        const len = await readN(1);
+        host = (await readN(len[0])).toString("utf-8");
+      } else if (atyp === ATYP_IPV6) {
+        const b = await readN(16);
+        host = Array.from({ length: 8 }, (_, i) => b.readUInt16BE(i * 2).toString(16)).join(":");
+      } else {
+        rep(REP_ATYP_NOT_SUPPORTED); socket.end(); return;
+      }
+      const port = (await readN(2)).readUInt16BE(0);
+
+      // Phase 3: Forward via upstream (S-M1-4)
+      void host; void port; void this.socksClient; void this.log;
+      socket.destroy();
+    } catch {
+      socket.destroy();
+    }
   }
 }

--- a/packages/qwen-proxy/tests/pool/proxy-pool.test.ts
+++ b/packages/qwen-proxy/tests/pool/proxy-pool.test.ts
@@ -163,6 +163,14 @@ describe("normalizeSocksUrl", () => {
     expect(normalizeSocksUrl("socks5://myuser:mypass@host.example.com:9999", undefined, undefined)).toBe("socks5://myuser:mypass@host.example.com:9999");
   });
 
+  it("does not double-encode percent-encoded URL creds (round-trip safe)", () => {
+    // Input has percent-encoded creds (@ → %40). normalizeSocksUrl must NOT
+    // re-encodeURIComponent them (WHATWG URL already stores them encoded).
+    const input = "socks5://us%40er:p%40ss@proxy:1080";
+    const normalized = normalizeSocksUrl(input, undefined, undefined);
+    expect(normalized).toBe("socks5://us%40er:p%40ss@proxy:1080");
+  });
+
   it("rejects empty string", () => {
     expect(normalizeSocksUrl("", undefined, undefined)).toBeNull();
   });

--- a/packages/qwen-proxy/tests/upstream/baxia-token.test.ts
+++ b/packages/qwen-proxy/tests/upstream/baxia-token.test.ts
@@ -605,4 +605,109 @@ describe("BaxiaTokenManager", () => {
       expect(mgr.status().consecutiveFailures).toBe(2);
     });
   });
+
+  // ── S-M1-5: per-proxy cache tests ──────────────────────────────────────
+
+  describe("per-proxy cache", () => {
+    function makeProxySetup(overrides: Partial<BaxiaTokenManagerConfig> = {}) {
+      let evalCount = 0;
+      const replyMap = new Map<string, (id: number, params: any) => any>();
+      replyMap.set("Page.enable", () => ({}));
+      replyMap.set("Runtime.enable", () => ({}));
+      replyMap.set("Page.navigate", () => ({ frameId: "f1" }));
+      replyMap.set("Runtime.evaluate", (_id, params) => {
+        if (params?.expression?.includes("__baxia__")) {
+          evalCount++;
+          const uid = "T2gA" + String.fromCharCode(65 + evalCount - 1).repeat(24);
+          return { result: { type: "object", value: { ready: true, fy: "FY" + evalCount, uid, cookie: "ck" + evalCount } } };
+        }
+        return { result: { type: "undefined" } };
+      });
+
+      let currentTime = 1000;
+      const nowFn = vi.fn(() => currentTime);
+      const spawnFn = vi.fn(() => ({ pid: 1, kill: vi.fn() }));
+      const fetcherFn = vi.fn(async (url: string) => {
+        if (url.includes("/json/list")) {
+          return { ok: true, json: async () => [{ type: "page", webSocketDebuggerUrl: "ws://127.0.0.1:9222/devtools/page/abc" }] };
+        }
+        return { ok: false, json: async () => ({}) };
+      });
+
+      const config = makeConfig({
+        spawn: spawnFn as any,
+        WebSocketCtor: function (url: string) { return new FakeWebSocket(url, replyMap) as any; } as any,
+        fetcher: fetcherFn as any,
+        sleep: () => Promise.resolve(),
+        now: nowFn,
+        ...overrides,
+      });
+
+      return { spawnFn, config, evalCount: () => evalCount, advance: (ms: number) => { currentTime += ms; } };
+    }
+
+    it("per-proxy separates: A then B → 2 distinct tokens, 2 spawns; A within TTL → 0 spawns", async () => {
+      const { BaxiaTokenManager } = await import("../../src/upstream/baxia-token");
+      const { spawnFn, config, advance } = makeProxySetup();
+      const mgr = new BaxiaTokenManager(config);
+
+      const tA = await mgr.ensureToken({ proxy: "socks5://u:p@proxyA:1080" });
+      expect(spawnFn).toHaveBeenCalledTimes(1);
+
+      const tB = await mgr.ensureToken({ proxy: "socks5://u:p@proxyB:1080" });
+      expect(spawnFn).toHaveBeenCalledTimes(2);
+      expect(tB.bxUmidToken).not.toBe(tA.bxUmidToken); // distinct tokens
+
+      advance(60_000);
+      const tA2 = await mgr.ensureToken({ proxy: "socks5://u:p@proxyA:1080" });
+      expect(spawnFn).toHaveBeenCalledTimes(2); // cache hit for A
+      expect(tA2.bxUmidToken).toBe(tA.bxUmidToken);
+    });
+
+    it("lazy spawn: TTL per proxy; DIRECT_KEY unaffected", async () => {
+      const { BaxiaTokenManager } = await import("../../src/upstream/baxia-token");
+      const { spawnFn, config, advance } = makeProxySetup();
+      const mgr = new BaxiaTokenManager(config);
+
+      await mgr.ensureToken({ proxy: "socks5://u:p@proxyA:1080" });
+      expect(spawnFn).toHaveBeenCalledTimes(1);
+
+      // DIRECT_KEY (no proxy) should still be a separate cache
+      await mgr.ensureToken();
+      expect(spawnFn).toHaveBeenCalledTimes(2); // separate spawn for direct
+
+      // Proxy A cache hit
+      advance(60_000);
+      await mgr.ensureToken({ proxy: "socks5://u:p@proxyA:1080" });
+      expect(spawnFn).toHaveBeenCalledTimes(2);
+    });
+
+    it("same-proxy piggyback: Promise.all same proxy → 1 spawn", async () => {
+      const { BaxiaTokenManager } = await import("../../src/upstream/baxia-token");
+      const { spawnFn, config } = makeProxySetup();
+      const mgr = new BaxiaTokenManager(config);
+
+      const proxy = "socks5://u:p@proxyA:1080";
+      const [t1, t2] = await Promise.all([
+        mgr.ensureToken({ proxy }),
+        mgr.ensureToken({ proxy }),
+      ]);
+      expect(t1.bxUmidToken).toBe(t2.bxUmidToken);
+      expect(spawnFn).toHaveBeenCalledTimes(1); // piggybacked
+    });
+
+    it("legacy ≡ today: ensureToken() twice within TTL → 1 spawn", async () => {
+      const { BaxiaTokenManager } = await import("../../src/upstream/baxia-token");
+      const { spawnFn, config, advance } = makeProxySetup();
+      const mgr = new BaxiaTokenManager(config);
+
+      const t1 = await mgr.ensureToken();
+      expect(spawnFn).toHaveBeenCalledTimes(1);
+
+      advance(60_000);
+      const t2 = await mgr.ensureToken();
+      expect(spawnFn).toHaveBeenCalledTimes(1);
+      expect(t2.bxUmidToken).toBe(t1.bxUmidToken);
+    });
+  });
 });

--- a/packages/qwen-proxy/tests/upstream/baxia-token.test.ts
+++ b/packages/qwen-proxy/tests/upstream/baxia-token.test.ts
@@ -604,6 +604,30 @@ describe("BaxiaTokenManager", () => {
       await expect(mgr.ensureToken()).rejects.toThrow();
       expect(mgr.status().consecutiveFailures).toBe(2);
     });
+
+    it("cold failure (no prior entry) → cachedAt:null, ageMs:null, no epoch-0 leak", async () => {
+      const { BaxiaTokenManager } = await import("../../src/upstream/baxia-token");
+      const fetcherFn = vi.fn(async () => { throw new Error("network down"); });
+
+      const config = makeConfig({
+        spawn: vi.fn(() => ({ pid: 1, kill: vi.fn() })) as any,
+        WebSocketCtor: function (url: string) { return new FakeWebSocket(url, makeDefaultReplyMap()) as any; } as any,
+        fetcher: fetcherFn as any,
+        sleep: () => Promise.resolve(),
+        now: () => 1000,
+        fallback: false,
+      });
+
+      const mgr = new BaxiaTokenManager(config);
+
+      // Cold failure: no prior token exists
+      await expect(mgr.ensureToken()).rejects.toThrow();
+      const s = mgr.status();
+      expect(s.cached).toBe(false);
+      expect(s.cachedAt).toBeNull(); // no epoch-0 leak
+      expect(s.ageMs).toBeNull();    // no huge ageMs
+      expect(s.consecutiveFailures).toBe(1);
+    });
   });
 
   // ── S-M1-5: per-proxy cache tests ──────────────────────────────────────

--- a/packages/qwen-proxy/tests/upstream/baxia-token.test.ts
+++ b/packages/qwen-proxy/tests/upstream/baxia-token.test.ts
@@ -711,3 +711,65 @@ describe("BaxiaTokenManager", () => {
     });
   });
 });
+
+// ── S-M1-6: global serialization + fallback + status (simplified) ─────────
+describe("global serialization + fallback + status", () => {
+  function makeProxySetup(overrides: Partial<BaxiaTokenManagerConfig> = {}) {
+    let evalCount = 0;
+    const replyMap = new Map<string, (id: number, params: any) => any>();
+    replyMap.set("Page.enable", () => ({}));
+    replyMap.set("Runtime.enable", () => ({}));
+    replyMap.set("Page.navigate", () => ({ frameId: "f1" }));
+    replyMap.set("Runtime.evaluate", (_id, params) => {
+      if (params?.expression?.includes("__baxia__")) { evalCount++;
+        const uid = "T2gA" + String.fromCharCode(65 + evalCount - 1).repeat(24);
+        return { result: { type: "object", value: { ready: true, fy: "FY" + evalCount, uid, cookie: "ck" + evalCount } } }; }
+      return { result: { type: "undefined" } }; });
+    let currentTime = 1000; const nowFn = vi.fn(() => currentTime);
+    const spawnFn = vi.fn(() => ({ pid: 1, kill: vi.fn() }));
+    const fetcherFn = vi.fn(async (url: string) => {
+      if (url.includes("/json/list")) return { ok: true, json: async () => [{ type: "page", webSocketDebuggerUrl: "ws://127.0.0.1:9222/devtools/page/abc" }] };
+      return { ok: false, json: async () => ({}) }; });
+    const config = makeConfig({ spawn: spawnFn as any, WebSocketCtor: function (url: string) { return new FakeWebSocket(url, replyMap) as any; } as any,
+      fetcher: fetcherFn as any, sleep: () => Promise.resolve(), now: nowFn, ...overrides });
+    return { spawnFn, config, evalCount: () => evalCount, advance: (ms: number) => { currentTime += ms; } };
+  }
+
+  it("concurrent A+B → 2 spawns, distinct tokens (serialized via withSpawnLock)", async () => {
+    const { BaxiaTokenManager } = await import("../../src/upstream/baxia-token");
+    const { spawnFn, config } = makeProxySetup();
+    const mgr = new BaxiaTokenManager(config);
+    const [tA, tB] = await Promise.all([
+      mgr.ensureToken({ proxy: "socks5://u:p@A:1080" }),
+      mgr.ensureToken({ proxy: "socks5://u:p@B:1080" }),
+    ]);
+    expect(spawnFn).toHaveBeenCalledTimes(2);
+    expect(tA.bxUmidToken).not.toBe(tB.bxUmidToken);
+  });
+
+  it("fallback:true on fail → returns same-proxy stale token", async () => {
+    const { BaxiaTokenManager } = await import("../../src/upstream/baxia-token");
+    const { config, advance } = makeProxySetup({ fallback: true });
+    const mgr = new BaxiaTokenManager(config);
+    const proxy = "socks5://u:p@A:1080";
+    const t1 = await mgr.ensureToken({ proxy });
+    advance(999_999); // past TTL
+    // Make fetcher fail → getBaxiaTokens throws → stale fallback
+    (config.fetcher as any).mockImplementation(async () => ({ ok: false, json: async () => ({}) }));
+    const t2 = await mgr.ensureToken({ proxy, forceRefresh: true });
+    expect(t2.bxUmidToken).toBe(t1.bxUmidToken); // stale token returned
+  });
+
+  it("status after seeding proxy X: cached + proxyStatuses has X", async () => {
+    const { BaxiaTokenManager } = await import("../../src/upstream/baxia-token");
+    const { config, advance } = makeProxySetup();
+    const mgr = new BaxiaTokenManager(config);
+    await mgr.ensureToken({ proxy: "socks5://u:p@X:1080" });
+    advance(5000);
+    expect(mgr.status().cached).toBe(true);
+    expect(mgr.status().ageMs).toBe(5000);
+    const ps = mgr.proxyStatuses();
+    expect(ps["socks5://u:p@X:1080"]).toBeDefined();
+    expect(ps["socks5://u:p@X:1080"].cached).toBe(true);
+  });
+});

--- a/packages/qwen-proxy/tests/upstream/baxia-token.test.ts
+++ b/packages/qwen-proxy/tests/upstream/baxia-token.test.ts
@@ -773,3 +773,97 @@ describe("global serialization + fallback + status", () => {
     expect(ps["socks5://u:p@X:1080"].cached).toBe(true);
   });
 });
+
+// ── S-M1-7: bridge integration ─────────────────────────────────────────────
+describe("bridge integration", () => {
+  function makeBridgeSetup(bridgePort = 12345) {
+    const setUpstreamFn = vi.fn();
+    const fakeBridge = {
+      getPort: () => bridgePort,
+      setUpstream: setUpstreamFn,
+    };
+
+    let evalCount = 0;
+    const replyMap = new Map<string, (id: number, params: any) => any>();
+    replyMap.set("Page.enable", () => ({}));
+    replyMap.set("Runtime.enable", () => ({}));
+    replyMap.set("Page.navigate", () => ({ frameId: "f1" }));
+    replyMap.set("Runtime.evaluate", (_id, params) => {
+      if (params?.expression?.includes("__baxia__")) { evalCount++;
+        const uid = "T2gA" + String.fromCharCode(65 + evalCount - 1).repeat(24);
+        return { result: { type: "object", value: { ready: true, fy: "FY" + evalCount, uid, cookie: "ck" + evalCount } } }; }
+      return { result: { type: "undefined" } }; });
+    let currentTime = 1000; const nowFn = vi.fn(() => currentTime);
+    const spawnFn = vi.fn(() => ({ pid: 1, kill: vi.fn() }));
+    const fetcherFn = vi.fn(async (url: string) => {
+      if (url.includes("/json/list")) return { ok: true, json: async () => [{ type: "page", webSocketDebuggerUrl: "ws://127.0.0.1:9222/devtools/page/abc" }] };
+      return { ok: false, json: async () => ({}) }; });
+
+    const config = makeConfig({ spawn: spawnFn as any, WebSocketCtor: function (url: string) { return new FakeWebSocket(url, replyMap) as any; } as any,
+      fetcher: fetcherFn as any, sleep: () => Promise.resolve(), now: nowFn, bridge: fakeBridge as any });
+    return { spawnFn, setUpstreamFn, config, fakeBridge, advance: (ms: number) => { currentTime += ms; } };
+  }
+
+  it("rotation: spawn gets --proxy-server + --host-resolver-rules args", async () => {
+    const { BaxiaTokenManager } = await import("../../src/upstream/baxia-token");
+    const { spawnFn, config } = makeBridgeSetup(9999);
+    const mgr = new BaxiaTokenManager(config);
+
+    await mgr.ensureToken({ proxy: "socks5://u:p@proxyA:1080" });
+
+    expect(spawnFn).toHaveBeenCalledTimes(1);
+    const args = (spawnFn.mock.calls[0] as any)[1] as string[];
+    expect(args).toContain("--proxy-server=socks5://127.0.0.1:9999");
+    expect(args).toContain("--host-resolver-rules=MAP * ~NOTFOUND, EXCLUDE 127.0.0.1");
+  });
+
+  it("rotation: bridge.setUpstream called with proxy key before getBaxiaTokens", async () => {
+    const { BaxiaTokenManager } = await import("../../src/upstream/baxia-token");
+    const { spawnFn, setUpstreamFn, config } = makeBridgeSetup();
+    const mgr = new BaxiaTokenManager(config);
+
+    const proxy = "socks5://u:p@proxyA:1080";
+    await mgr.ensureToken({ proxy });
+
+    expect(setUpstreamFn).toHaveBeenCalledWith(proxy);
+    // setUpstream must be called BEFORE spawn (which calls getBaxiaTokens)
+    expect(setUpstreamFn.mock.invocationCallOrder[0]).toBeLessThan(
+      spawnFn.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("legacy (no bridge): spawn gets NEITHER --proxy-server NOR --host-resolver-rules", async () => {
+    const { BaxiaTokenManager } = await import("../../src/upstream/baxia-token");
+    const replyMap = makeDefaultReplyMap();
+    const spawnFn = vi.fn(() => ({ pid: 1, kill: vi.fn() }));
+    const fetcherFn = vi.fn(async (url: string) => {
+      if (url.includes("/json/list")) return { ok: true, json: async () => [{ type: "page", webSocketDebuggerUrl: "ws://127.0.0.1:9222/devtools/page/abc" }] };
+      return { ok: false, json: async () => ({}) }; });
+
+    const config = makeConfig({ spawn: spawnFn as any, WebSocketCtor: function (url: string) { return new FakeWebSocket(url, replyMap) as any; } as any,
+      fetcher: fetcherFn as any, sleep: () => Promise.resolve(), now: () => 1000 });
+    const mgr = new BaxiaTokenManager(config);
+
+    await mgr.ensureToken();
+
+    const args = (spawnFn.mock.calls[0] as any)[1] as string[];
+    expect(args).not.toContain(expect.stringMatching(/--proxy-server/));
+    expect(args).not.toContain(expect.stringMatching(/--host-resolver-rules/));
+  });
+
+  it("lazy refresh: startRefreshLoop is no-op when bridge set, no setInterval", async () => {
+    const { BaxiaTokenManager } = await import("../../src/upstream/baxia-token");
+    const setIntervalSpy = vi.spyOn(global, "setInterval");
+    try {
+      const { config } = makeBridgeSetup();
+      const mgr = new BaxiaTokenManager(config);
+
+      mgr.startRefreshLoop();
+
+      expect(setIntervalSpy).not.toHaveBeenCalled();
+      expect(mgr.status().nextRefreshInMs).toBeNull();
+    } finally {
+      setIntervalSpy.mockRestore();
+    }
+  });
+});

--- a/packages/qwen-proxy/tests/upstream/guest-client.test.ts
+++ b/packages/qwen-proxy/tests/upstream/guest-client.test.ts
@@ -121,7 +121,9 @@ describe("createChatSession", () => {
 
     expect(result).toBe("session-retry");
     expect(fetcher).toHaveBeenCalledTimes(2);
-    expect(baxia.ensureToken).toHaveBeenCalledWith({ forceRefresh: true });
+    expect(baxia.ensureToken).toHaveBeenCalledTimes(2);
+    expect(baxia.ensureToken).toHaveBeenNthCalledWith(1, { proxy: undefined });
+    expect(baxia.ensureToken).toHaveBeenNthCalledWith(2, { forceRefresh: true, proxy: undefined });
   });
 
   it("P1: rgv587 retry uses FRESH (not stale) bx-* headers after forceRefresh", async () => {
@@ -178,8 +180,8 @@ describe("createChatSession", () => {
 
     // (a) ensureToken was called with forceRefresh after the rgv587
     expect(ensureTokenMock).toHaveBeenCalledTimes(2);
-    expect(ensureTokenMock).toHaveBeenNthCalledWith(1, undefined);
-    expect(ensureTokenMock).toHaveBeenNthCalledWith(2, { forceRefresh: true });
+    expect(ensureTokenMock).toHaveBeenNthCalledWith(1, { proxy: undefined });
+    expect(ensureTokenMock).toHaveBeenNthCalledWith(2, { forceRefresh: true, proxy: undefined });
 
     // (b) The 2nd POST must carry FRESH headers, not STALE
     const [, retryInit] = fetcher.mock.calls[1];
@@ -797,7 +799,7 @@ describe("S-M1-5: proxy threading", () => {
     }
   });
 
-  it("ensureToken receives NO proxy arg (token-gen is direct)", async () => {
+  it("ensureToken receives {proxy} for proxy-affine token gen (S-M2-1)", async () => {
     const baxia = makeBaxia();
     const fetcher = vi.fn()
       .mockResolvedValueOnce({
@@ -825,22 +827,59 @@ describe("S-M1-5: proxy threading", () => {
       proxyDispatcherCache: cache,
     });
 
+    const proxyKey = "socks5://u:p@proxy:1080";
     const result = client.chatCompletions("ignored", {
       model: "qwen3-max",
       messages: [{ role: "user", content: "Hello" }],
       stream: true,
-    }, "socks5://u:p@proxy:1080");
+    }, proxyKey);
 
     for await (const _ of result as AsyncIterable<any>) { /* drain */ }
 
-    // ensureToken should be called without any proxy argument
-    for (const call of (baxia.ensureToken as any).mock.calls) {
-      // The only arg allowed is { forceRefresh } or undefined — never a proxy key
-      expect(call.length <= 1).toBe(true);
-      if (call[0]) {
-        expect(call[0]).toHaveProperty("forceRefresh");
-      }
-    }
+    // S-M2-1: ensureToken receives {proxy} in both call sites
+    const calls = (baxia.ensureToken as any).mock.calls;
+    // First call: createChatSession → ensureToken({proxy})
+    expect(calls[0][0]).toEqual({ proxy: proxyKey });
+    // Second call: doChatCompletionsRequest → ensureToken({proxy})
+    expect(calls[1][0]).toEqual({ proxy: proxyKey });
+  });
+
+  it("ensureToken receives {proxy:undefined} in legacy mode (no proxy arg)", async () => {
+    const baxia = makeBaxia();
+    const fetcher = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ data: { id: "sid" } }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        body: new ReadableStream({
+          start(c) {
+            c.enqueue(new TextEncoder().encode('data: [DONE]\n'));
+            c.close();
+          },
+        }),
+      });
+
+    const client = new GuestUpstreamClient({
+      baxia,
+      chatUrl: "https://chat.qwen.ai",
+      fetcher: fetcher as unknown as typeof fetch,
+      log: noopLog,
+    });
+
+    const result = client.chatCompletions("ignored", {
+      model: "qwen3-max",
+      messages: [{ role: "user", content: "Hello" }],
+      stream: true,
+    });
+
+    for await (const _ of result as AsyncIterable<any>) { /* drain */ }
+
+    // S-M2-1: ensureToken({proxy:undefined}) in legacy mode
+    const calls = (baxia.ensureToken as any).mock.calls;
+    expect(calls[0][0]).toEqual({ proxy: undefined });
+    expect(calls[1][0]).toEqual({ proxy: undefined });
   });
 
   it("timeoutMs defaults to 60_000 when not provided", () => {

--- a/packages/qwen-proxy/tests/upstream/proxy-bridge.test.ts
+++ b/packages/qwen-proxy/tests/upstream/proxy-bridge.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import * as net from "node:net";
 import { ProxyBridge } from "../../src/upstream/proxy-bridge";
+import { normalizeSocksUrl } from "../../src/pool/proxy-pool";
 
 // S-M1-1: parseSocksUrl
 describe("parseSocksUrl", () => {
@@ -56,6 +57,18 @@ describe("parseSocksUrl", () => {
     const mod = await import("../../src/upstream/proxy-bridge");
     parseSocksUrl = mod.parseSocksUrl;
     expect(() => parseSocksUrl("socks5://proxy:1080")).toThrow(/cred/i);
+  });
+
+  it("round-trip: normalizeSocksUrl → parseSocksUrl preserves creds with special chars", async () => {
+    const mod = await import("../../src/upstream/proxy-bridge");
+    parseSocksUrl = mod.parseSocksUrl;
+    // User provides creds with special chars (e.g. @ encoded as %40)
+    const input = "socks5://us%40er:p%40ss@proxy:1080";
+    const normalized = normalizeSocksUrl(input, undefined, undefined);
+    expect(normalized).not.toBeNull();
+    const parsed = parseSocksUrl(normalized!);
+    expect(parsed.user).toBe("us@er");
+    expect(parsed.pass).toBe("p@ss");
   });
 });
 

--- a/packages/qwen-proxy/tests/upstream/proxy-bridge.test.ts
+++ b/packages/qwen-proxy/tests/upstream/proxy-bridge.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import * as net from "node:net";
+import { ProxyBridge } from "../../src/upstream/proxy-bridge";
 
 // S-M1-1: parseSocksUrl
 describe("parseSocksUrl", () => {
@@ -124,5 +125,47 @@ describe("ProxyBridge", () => {
     const cur = bridge.getCurrentUpstream();
     expect(cur).toEqual({ host: "proxy.example.com", port: 1080, user: "alice", pass: "s3cret" });
     await bridge.stop();
+  });
+});
+
+// ── S-M1-3: SOCKS5 handshake tests ────────────────────────────────────────
+
+describe("ProxyBridge SOCKS5 handshake", () => {
+  async function bridgeAndConnect() {
+    const bridge = new ProxyBridge({ log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() } });
+    const port = await bridge.start();
+    const sock = net.createConnection({ host: "127.0.0.1", port });
+    await new Promise<void>((res, rej) => { sock.on("connect", res); sock.on("error", rej); });
+    return { bridge, sock };
+  }
+  function readN(sock: net.Socket, n: number): Promise<Buffer> {
+    return new Promise((resolve, reject) => {
+      const chunks: Buffer[] = []; let total = 0;
+      const onData = (c: Buffer) => { chunks.push(c); total += c.length; if (total >= n) { sock.off("data", onData); resolve(Buffer.concat(chunks).subarray(0, n)); } };
+      const onEnd = () => { sock.off("data", onData); reject(new Error("closed")); };
+      sock.on("data", onData); sock.once("close", onEnd);
+      setTimeout(() => { sock.off("data", onData); sock.off("close", onEnd); reject(new Error("timeout")); }, 2000);
+    });
+  }
+
+  it("no-auth accept: 05 01 00 → reply 05 00", async () => {
+    const { bridge, sock } = await bridgeAndConnect();
+    try { sock.write(Buffer.from([0x05, 0x01, 0x00])); const r = await readN(sock, 2); expect(r[0]).toBe(0x05); expect(r[1]).toBe(0x00); }
+    finally { sock.destroy(); await bridge.stop(); }
+  });
+  it("no-acceptable-auth: 05 01 02 → reply 05 FF", async () => {
+    const { bridge, sock } = await bridgeAndConnect();
+    try { sock.write(Buffer.from([0x05, 0x01, 0x02])); const r = await readN(sock, 2); expect(r[1]).toBe(0xFF); }
+    finally { sock.destroy(); await bridge.stop(); }
+  });
+  it("CMD≠CONNECT → REP 0x07", async () => {
+    const { bridge, sock } = await bridgeAndConnect();
+    try { sock.write(Buffer.from([0x05, 0x01, 0x00])); await readN(sock, 2); sock.write(Buffer.from([0x05, 0x02, 0x00, 0x01, 1, 2, 3, 4, 0, 80])); const r = await readN(sock, 2); expect(r[1]).toBe(0x07); }
+    finally { sock.destroy(); await bridge.stop(); }
+  });
+  it("unrecognized ATYP → REP 0x08", async () => {
+    const { bridge, sock } = await bridgeAndConnect();
+    try { sock.write(Buffer.from([0x05, 0x01, 0x00])); await readN(sock, 2); sock.write(Buffer.from([0x05, 0x01, 0x00, 0x09])); const r = await readN(sock, 2); expect(r[1]).toBe(0x08); }
+    finally { sock.destroy(); await bridge.stop(); }
   });
 });

--- a/packages/qwen-proxy/tests/upstream/proxy-bridge.test.ts
+++ b/packages/qwen-proxy/tests/upstream/proxy-bridge.test.ts
@@ -169,3 +169,166 @@ describe("ProxyBridge SOCKS5 handshake", () => {
     finally { sock.destroy(); await bridge.stop(); }
   });
 });
+
+// ── S-M1-4: ProxyBridge forwarding tests ───────────────────────────────────
+
+describe("ProxyBridge forwarding", () => {
+  const PROXY_A = "socks5://alice:passA@proxy-a:1080";
+  const PROXY_B = "socks5://bob:passB@proxy-b:2080";
+
+  function readN(sock: net.Socket, n: number): Promise<Buffer> {
+    return new Promise((resolve, reject) => {
+      const chunks: Buffer[] = []; let total = 0;
+      const onData = (c: Buffer) => { chunks.push(c); total += c.length; if (total >= n) { sock.off("data", onData); resolve(Buffer.concat(chunks).subarray(0, n)); } };
+      const onEnd = () => { sock.off("data", onData); reject(new Error("closed")); };
+      sock.on("data", onData); sock.once("close", onEnd);
+      setTimeout(() => { sock.off("data", onData); sock.off("close", onEnd); reject(new Error("timeout")); }, 3000);
+    });
+  }
+
+  /** Complete the SOCKS5 handshake + CONNECT on a client socket */
+  async function socks5Connect(sock: net.Socket, destHost: string, destPort: number) {
+    sock.write(Buffer.from([0x05, 0x01, 0x00]));
+    await readN(sock, 2); // 05 00
+    const hostBuf = Buffer.from(destHost, "utf-8");
+    const connectReq = Buffer.alloc(7 + hostBuf.length);
+    connectReq[0] = 0x05;
+    connectReq[1] = 0x01;
+    connectReq[2] = 0x00;
+    connectReq[3] = 0x03; // ATYP domain
+    connectReq[4] = hostBuf.length;
+    hostBuf.copy(connectReq, 5);
+    connectReq.writeUInt16BE(destPort, 5 + hostBuf.length);
+    sock.write(connectReq);
+  }
+
+  function makeFakeSocksClient(rejectWith?: Error) {
+    const calls: any[] = [];
+    return {
+      createConnection: vi.fn(async (opts: any) => {
+        calls.push(opts);
+        if (rejectWith) throw rejectWith;
+        // Return {socket} to match socks library return shape
+        const echoServer = net.createServer((s) => s.pipe(s));
+        await new Promise<void>((res) => echoServer.listen(0, "127.0.0.1", res));
+        const echoPort = (echoServer.address() as net.AddressInfo).port;
+        const remote = net.createConnection({ host: "127.0.0.1", port: echoPort });
+        await new Promise<void>((res, rej) => { remote.on("connect", res); remote.on("error", rej); });
+        remote.once("close", () => echoServer.close());
+        return { socket: remote };
+      }),
+      calls,
+    };
+  }
+
+  it("CONNECT uses currentUpstream creds + destination domain", async () => {
+    const fake = makeFakeSocksClient();
+    const bridge = new ProxyBridge({ log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() }, socksClient: fake as any });
+    await bridge.start();
+    bridge.setUpstream(PROXY_A);
+
+    const sock = net.createConnection({ host: "127.0.0.1", port: bridge.getPort() });
+    await new Promise<void>((res, rej) => { sock.on("connect", res); sock.on("error", rej); });
+    await socks5Connect(sock, "chat.qwen.ai", 443);
+    const reply = await readN(sock, 10);
+    expect(reply[0]).toBe(0x05);
+    expect(reply[1]).toBe(0x00); // success
+
+    expect(fake.createConnection).toHaveBeenCalledTimes(1);
+    const opts = fake.calls[0];
+    expect(opts.command).toBe("connect");
+    expect(opts.destination).toEqual({ host: "chat.qwen.ai", port: 443 });
+    expect(opts.proxy.host).toBe("proxy-a");
+    expect(opts.proxy.port).toBe(1080);
+    expect(opts.proxy.userId).toBe("alice");
+    expect(opts.proxy.password).toBe("passA");
+    expect(opts.proxy.type).toBe(5);
+
+    sock.destroy();
+    await bridge.stop();
+  });
+
+  it("setUpstream swap — sequential CONNECTs use different creds", async () => {
+    const fake = makeFakeSocksClient();
+    const bridge = new ProxyBridge({ log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() }, socksClient: fake as any });
+    await bridge.start();
+
+    bridge.setUpstream(PROXY_A);
+    const sock1 = net.createConnection({ host: "127.0.0.1", port: bridge.getPort() });
+    await new Promise<void>((res, rej) => { sock1.on("connect", res); sock1.on("error", rej); });
+    await socks5Connect(sock1, "host1.com", 443);
+    await readN(sock1, 10);
+    expect(fake.calls[0].proxy.userId).toBe("alice");
+    sock1.destroy();
+
+    bridge.setUpstream(PROXY_B);
+    const sock2 = net.createConnection({ host: "127.0.0.1", port: bridge.getPort() });
+    await new Promise<void>((res, rej) => { sock2.on("connect", res); sock2.on("error", rej); });
+    await socks5Connect(sock2, "host2.com", 443);
+    await readN(sock2, 10);
+    expect(fake.calls[1].proxy.userId).toBe("bob");
+    expect(fake.calls[1].proxy.host).toBe("proxy-b");
+    sock2.destroy();
+
+    await bridge.stop();
+  });
+
+  it("bidirectional pipe — data flows both directions", async () => {
+    const fake = makeFakeSocksClient();
+    const bridge = new ProxyBridge({ log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() }, socksClient: fake as any });
+    await bridge.start();
+    bridge.setUpstream(PROXY_A);
+
+    const client = net.createConnection({ host: "127.0.0.1", port: bridge.getPort() });
+    await new Promise<void>((res, rej) => { client.on("connect", res); client.on("error", rej); });
+    await socks5Connect(client, "echo.local", 7);
+    await readN(client, 10);
+
+    const testMsg = "hello-bridge";
+    client.write(testMsg);
+    const echoed = await new Promise<Buffer>((resolve, reject) => {
+      const chunks: Buffer[] = [];
+      const onData = (c: Buffer) => { chunks.push(c); if (Buffer.concat(chunks).length >= testMsg.length) { client.off("data", onData); resolve(Buffer.concat(chunks)); } };
+      client.on("data", onData);
+      setTimeout(() => reject(new Error("timeout")), 3000);
+    });
+    expect(echoed.toString()).toBe(testMsg);
+
+    client.destroy();
+    await bridge.stop();
+  });
+
+  it("upstream error → REP 0x01", async () => {
+    const fake = makeFakeSocksClient(new Error("connection refused"));
+    const bridge = new ProxyBridge({ log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() }, socksClient: fake as any });
+    await bridge.start();
+    bridge.setUpstream(PROXY_A);
+
+    const sock = net.createConnection({ host: "127.0.0.1", port: bridge.getPort() });
+    await new Promise<void>((res, rej) => { sock.on("connect", res); sock.on("error", rej); });
+    await socks5Connect(sock, "unreachable.com", 443);
+    const reply = await readN(sock, 10);
+    expect(reply[0]).toBe(0x05);
+    expect(reply[1]).toBe(0x01); // general failure
+
+    sock.destroy();
+    await bridge.stop();
+  });
+
+  it("no upstream set → REP 0x01", async () => {
+    const fake = makeFakeSocksClient();
+    const bridge = new ProxyBridge({ log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() }, socksClient: fake as any });
+    await bridge.start();
+    // No setUpstream call
+
+    const sock = net.createConnection({ host: "127.0.0.1", port: bridge.getPort() });
+    await new Promise<void>((res, rej) => { sock.on("connect", res); sock.on("error", rej); });
+    await socks5Connect(sock, "chat.qwen.ai", 443);
+    const reply = await readN(sock, 10);
+    expect(reply[0]).toBe(0x05);
+    expect(reply[1]).toBe(0x01); // general failure
+
+    sock.destroy();
+    await bridge.stop();
+  });
+});

--- a/packages/qwen-proxy/tests/upstream/proxy-bridge.test.ts
+++ b/packages/qwen-proxy/tests/upstream/proxy-bridge.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
+import * as net from "node:net";
 
 // S-M1-1: parseSocksUrl
 describe("parseSocksUrl", () => {
@@ -54,5 +55,74 @@ describe("parseSocksUrl", () => {
     const mod = await import("../../src/upstream/proxy-bridge");
     parseSocksUrl = mod.parseSocksUrl;
     expect(() => parseSocksUrl("socks5://proxy:1080")).toThrow(/cred/i);
+  });
+});
+
+// S-M1-2: ProxyBridge lifecycle + loopback + setUpstream
+describe("ProxyBridge", () => {
+  async function createBridge(overrides?: Record<string, unknown>) {
+    const mod = await import("../../src/upstream/proxy-bridge");
+    return new mod.ProxyBridge({ log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() }, ...overrides });
+  }
+
+  it("start returns port > 0 and isStarted becomes true", async () => {
+    const bridge = await createBridge();
+    expect(bridge.isStarted()).toBe(false);
+    const port = await bridge.start();
+    expect(port).toBeGreaterThan(0);
+    expect(bridge.isStarted()).toBe(true);
+    expect(bridge.getPort()).toBe(port);
+    await bridge.stop();
+  });
+
+  it("getPort throws before start", async () => {
+    const bridge = await createBridge();
+    expect(() => bridge.getPort()).toThrow(/not started/i);
+  });
+
+  it("start is idempotent (same port on 2nd call)", async () => {
+    const bridge = await createBridge();
+    const p1 = await bridge.start();
+    const p2 = await bridge.start();
+    expect(p2).toBe(p1);
+    await bridge.stop();
+  });
+
+  it("loopback: can connect to 127.0.0.1:<port> after start", async () => {
+    const bridge = await createBridge();
+    const port = await bridge.start();
+    const sock = net.createConnection({ host: "127.0.0.1", port });
+    await new Promise<void>((resolve, reject) => {
+      sock.on("connect", () => { sock.destroy(); resolve(); });
+      sock.on("error", reject);
+    });
+    await bridge.stop();
+  });
+
+  it("stop: connect refused after stop", async () => {
+    const bridge = await createBridge();
+    const port = await bridge.start();
+    await bridge.stop();
+    const sock = net.createConnection({ host: "127.0.0.1", port });
+    await expect(new Promise<void>((resolve, reject) => {
+      sock.on("connect", () => { sock.destroy(); resolve(); });
+      sock.on("error", reject);
+    })).rejects.toThrow();
+  });
+
+  it("stop is idempotent", async () => {
+    const bridge = await createBridge();
+    await bridge.start();
+    await bridge.stop();
+    await bridge.stop(); // no throw
+  });
+
+  it("setUpstream → getCurrentUpstream returns the parsed upstream", async () => {
+    const bridge = await createBridge();
+    await bridge.start();
+    bridge.setUpstream("socks5://alice:s3cret@proxy.example.com:1080");
+    const cur = bridge.getCurrentUpstream();
+    expect(cur).toEqual({ host: "proxy.example.com", port: 1080, user: "alice", pass: "s3cret" });
+    await bridge.stop();
   });
 });

--- a/packages/qwen-proxy/tests/upstream/proxy-bridge.test.ts
+++ b/packages/qwen-proxy/tests/upstream/proxy-bridge.test.ts
@@ -344,4 +344,77 @@ describe("ProxyBridge forwarding", () => {
     sock.destroy();
     await bridge.stop();
   });
+
+  // P3: pipeBoth should destroy peer on 'close' (not just 'error')
+  it("client close → destroys remote socket (no FD leak)", async () => {
+    let remoteSocket: net.Socket | undefined;
+    const fake = {
+      createConnection: vi.fn(async () => {
+        const echoServer = net.createServer((s) => s.pipe(s));
+        await new Promise<void>((res) => echoServer.listen(0, "127.0.0.1", res));
+        const echoPort = (echoServer.address() as net.AddressInfo).port;
+        const remote = net.createConnection({ host: "127.0.0.1", port: echoPort });
+        await new Promise<void>((res, rej) => { remote.on("connect", res); remote.on("error", rej); });
+        remote.once("close", () => echoServer.close());
+        remoteSocket = remote;
+        return { socket: remote };
+      }),
+    };
+    const bridge = new ProxyBridge({ log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() }, socksClient: fake as any });
+    await bridge.start();
+    bridge.setUpstream(PROXY_A);
+
+    const client = net.createConnection({ host: "127.0.0.1", port: bridge.getPort() });
+    await new Promise<void>((res, rej) => { client.on("connect", res); client.on("error", rej); });
+    await socks5Connect(client, "echo.local", 7);
+    await readN(client, 10);
+    // Bidirectional pipe is now active.
+
+    // Simulate Chromium SIGKILL: destroy the client socket (emits 'close', not 'error')
+    const remoteClosed = new Promise<void>((resolve) => {
+      remoteSocket!.once("close", () => resolve());
+    });
+    client.destroy(); // emits 'close' on client
+
+    // Remote should be destroyed within a short timeout
+    await expect(remoteClosed).resolves.toBeUndefined();
+    expect(remoteSocket!.destroyed).toBe(true);
+
+    await bridge.stop();
+  });
+
+  it("remote close → destroys client socket (reverse direction)", async () => {
+    let remoteSocket: net.Socket | undefined;
+    const fake = {
+      createConnection: vi.fn(async () => {
+        const echoServer = net.createServer((s) => s.pipe(s));
+        await new Promise<void>((res) => echoServer.listen(0, "127.0.0.1", res));
+        const echoPort = (echoServer.address() as net.AddressInfo).port;
+        const remote = net.createConnection({ host: "127.0.0.1", port: echoPort });
+        await new Promise<void>((res, rej) => { remote.on("connect", res); remote.on("error", rej); });
+        remote.once("close", () => echoServer.close());
+        remoteSocket = remote;
+        return { socket: remote };
+      }),
+    };
+    const bridge = new ProxyBridge({ log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() }, socksClient: fake as any });
+    await bridge.start();
+    bridge.setUpstream(PROXY_A);
+
+    const client = net.createConnection({ host: "127.0.0.1", port: bridge.getPort() });
+    await new Promise<void>((res, rej) => { client.on("connect", res); client.on("error", rej); });
+    await socks5Connect(client, "echo.local", 7);
+    await readN(client, 10);
+
+    // Simulate upstream disconnect: destroy remote socket
+    const clientClosed = new Promise<void>((resolve) => {
+      client.once("close", () => resolve());
+    });
+    remoteSocket!.destroy();
+
+    await expect(clientClosed).resolves.toBeUndefined();
+    expect(client.destroyed).toBe(true);
+
+    await bridge.stop();
+  });
 });

--- a/packages/qwen-proxy/tests/upstream/proxy-bridge.test.ts
+++ b/packages/qwen-proxy/tests/upstream/proxy-bridge.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+
+// S-M1-1: parseSocksUrl
+describe("parseSocksUrl", () => {
+  let parseSocksUrl: (key: string) => { host: string; port: number; user: string; pass: string };
+
+  it("parses socks5 URL with user:pass", async () => {
+    const mod = await import("../../src/upstream/proxy-bridge");
+    parseSocksUrl = mod.parseSocksUrl;
+    const r = parseSocksUrl("socks5://alice:secret@proxy.example.com:1080");
+    expect(r.host).toBe("proxy.example.com");
+    expect(r.port).toBe(1080);
+    expect(r.user).toBe("alice");
+    expect(r.pass).toBe("secret");
+  });
+
+  it("decodes URL-encoded credentials", async () => {
+    const mod = await import("../../src/upstream/proxy-bridge");
+    parseSocksUrl = mod.parseSocksUrl;
+    const r = parseSocksUrl("socks5://us%40er:p%40ss@proxy:1080");
+    expect(r.user).toBe("us@er");
+    expect(r.pass).toBe("p@ss");
+  });
+
+  it("defaults port to 1080 when omitted", async () => {
+    const mod = await import("../../src/upstream/proxy-bridge");
+    parseSocksUrl = mod.parseSocksUrl;
+    const r = parseSocksUrl("socks5://u:p@proxy");
+    expect(r.port).toBe(1080);
+  });
+
+  it("accepts socks5h protocol", async () => {
+    const mod = await import("../../src/upstream/proxy-bridge");
+    parseSocksUrl = mod.parseSocksUrl;
+    const r = parseSocksUrl("socks5h://u:p@proxy:2080");
+    expect(r.host).toBe("proxy");
+    expect(r.port).toBe(2080);
+  });
+
+  it("throws on http protocol", async () => {
+    const mod = await import("../../src/upstream/proxy-bridge");
+    parseSocksUrl = mod.parseSocksUrl;
+    expect(() => parseSocksUrl("http://u:p@proxy:1080")).toThrow(/socks5/);
+  });
+
+  it("throws on missing host", async () => {
+    const mod = await import("../../src/upstream/proxy-bridge");
+    parseSocksUrl = mod.parseSocksUrl;
+    // new URL() throws ERR_INVALID_URL for malformed host; our guard also covers empty hostname
+    expect(() => parseSocksUrl("socks5://:pass@:1080")).toThrow();
+  });
+
+  it("throws on missing credentials", async () => {
+    const mod = await import("../../src/upstream/proxy-bridge");
+    parseSocksUrl = mod.parseSocksUrl;
+    expect(() => parseSocksUrl("socks5://proxy:1080")).toThrow(/cred/i);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -339,6 +339,9 @@ importers:
       hono:
         specifier: ^4.6.0
         version: 4.12.27
+      socks:
+        specifier: ^2.8.9
+        version: 2.8.9
       socks-proxy-agent:
         specifier: ^10.1.0
         version: 10.1.0


### PR DESCRIPTION
## Summary

Fixes the **0/12 all-burned** failure in 0.4.0's proxy rotation: the Baxia token was generated direct (mini's IP) while completions egress through NordVPN IPs → Baxia's token-to-IP binding rejected every proxy. This PR makes token-gen **proxy-affine** via a local loopback SOCKS5 bridge that injects NordVPN credentials for Chromium (which can't do SOCKS5 auth natively). Tokens are now cached **per-proxy** so a completion on proxy X uses a token minted through X's NordVPN IP.

## What changed

- **NEW `src/upstream/proxy-bridge.ts`** — a pure-Node local SOCKS5-no-auth server (`net.Server` + `socks` package's `SocksClient`). Chromium points at `--proxy-server=socks5://127.0.0.1:<port>` (no auth); the bridge forwards to the active NordVPN SOCKS5 (with user:pass). Loopback-only, reconfigurable upstream, serialized under the global spawn mutex.
- **`src/upstream/baxia-token.ts`** — single `cached` → `Map<proxyKey, {tokens, cachedAt}>` + `DIRECT_KEY=""` sentinel; `ensureToken({proxy?,forceRefresh?})`; global spawn mutex (`withSpawnLock`); same-proxy stale fallback (never DIRECT_KEY); Chromium `--proxy-server` + `--host-resolver-rules` when proxy set; lazy refresh (no periodic loop in rotation); `setBridge()`; `status()` unchanged + `proxyStatuses()` additive.
- **`src/upstream/guest-client.ts`** — BOTH `ensureToken` call sites (createChatSession + doChatCompletionsRequest) pass `{proxy}`.
- **`bin/qwen-proxy.ts`** — rotation mode: construct+start the bridge → `setBridge` → skip pre-warm (lazy handles it) → shutdown: handle.close → baxia.stop → bridge.stop → db.close.
- **`package.json`** — + `socks` ^2.8.3 direct dep.
- **Docs** — "Token generation stays direct" → "proxy-affine"; "Token/IP-mismatch empirical limitation" → "Per-proxy token affinity (resolved)".

## Backward-compat

No proxyPool (size=0/undefined) → DIRECT_KEY, no bridge, single direct cache, all existing tests green. proxyPool present (size≥1) → bridge + per-proxy token cache.

## Validation

- **507 tests green**, typecheck clean.
- Flow gates: clarify (7 questions, all resolved — approach B bridge confirmed) → design → plan (REVISE→APPROVED after 2 P1 + 2 P2 fixes) → implement (10 stories) → impl-review (REVISE→APPROVED after 2 P2 fixes: ESM require→import + pre-warm skip) → audit (REVISE→APPROVED after P2 fix: refreshBaxiaToken threads proxy).
- **The decisive validation is LIVE (post-merge on mini):** a burst should go from 0/12 (all-burned) to ~12/12. The design is correct-by-construction: token-gen egress == completion egress per proxy via the shared bridge.

## Config

No new env vars (uses the existing `SF_QWEN_PROXY_COUNT` / `SF_QWEN_PROXY_USER` / `SF_QWEN_PROXY_PASS` from 0.4.0). The bridge starts automatically when a proxyPool is configured (size≥1).

## Constraints honored

`version` (0.4.0) + `CHANGELOG.md` untouched (AGENTS.md — `pnpm release` owns both → minor 0.5.0).
