### PR TITLE
fix(qwen-proxy): bridge socket ECONNRESET crash (lifetime error handlers)

### DIFF
--- a/packages/qwen-proxy/src/upstream/proxy-bridge.ts
+++ b/packages/qwen-proxy/src/upstream/proxy-bridge.ts
@@ -127,6 +127,11 @@ export class ProxyBridge {
    * (SOCKS5 handshake + forwarding — implemented in S-M1-3/S-M1-4.)
    */
   private async handleConnection(socket: net.Socket): Promise<void> {
+    // Lifetime error handler — installed BEFORE any await so a mid-lifecycle
+    // ECONNRESET (Chromium resetting a connection) can never become an unhandled
+    // 'error' event (which would crash the process). Destroying is the correct
+    // response; any pending readN rejects via its own close/error handling.
+    socket.on("error", () => socket.destroy());
     const VER = 0x05, AUTH_NONE = 0x00, AUTH_NO_ACCEPTABLE = 0xFF;
     const CMD_CONNECT = 0x01, REP_CMD_NOT_SUPPORTED = 0x07, REP_ATYP_NOT_SUPPORTED = 0x08;
     const ATYP_IPV4 = 0x01, ATYP_DOMAIN = 0x03, ATYP_IPV6 = 0x04;
@@ -209,6 +214,9 @@ export class ProxyBridge {
         timeout: 10_000,
       });
 
+      // Lifetime error handler on the remote socket too — before piping, so an
+      // upstream reset can never become an unhandled 'error' event (crash).
+      remote.on("error", () => remote.destroy());
       // Success reply: BND.ADDR = 127.0.0.1:0 (placeholder)
       client.write(Buffer.from([VER, 0x00, 0x00, 0x01, 127, 0, 0, 1, 0, 0]));
       this.pipeBoth(client, remote);

--- a/packages/qwen-proxy/tests/upstream/proxy-bridge.test.ts
+++ b/packages/qwen-proxy/tests/upstream/proxy-bridge.test.ts
@@ -418,3 +418,60 @@ describe("ProxyBridge forwarding", () => {
     await bridge.stop();
   });
 });
+
+// ── P0 regression: mid-lifecycle socket errors must never crash the process ─
+describe("ProxyBridge socket error resilience (ECONNRESET regression)", () => {
+  it("client socket destroyed mid-handshake → no unhandled error, bridge survives", async () => {
+    const { ProxyBridge: PB } = await import("../../src/upstream/proxy-bridge");
+    const bridge = new PB({ log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() } });
+    const port = await bridge.start();
+    try {
+      const sock = net.createConnection({ host: "127.0.0.1", port });
+      await new Promise<void>((res, rej) => { sock.on("connect", res); sock.on("error", rej); });
+      // Send a partial greeting then abruptly destroy (RST-like) — the bridge's
+      // readN is pending when the socket dies; without the lifetime error
+      // handler this becomes an unhandled 'error' event and crashes the process.
+      sock.write(Buffer.from([0x05, 0x01]));
+      sock.destroy();
+      await new Promise((r) => setTimeout(r, 100));
+      // Bridge still accepts new connections (did not crash):
+      const sock2 = net.createConnection({ host: "127.0.0.1", port });
+      await new Promise<void>((res, rej) => { sock2.on("connect", res); sock2.on("error", rej); });
+      sock2.write(Buffer.from([0x05, 0x01, 0x00]));
+      const reply = await new Promise<Buffer>((res, rej) => {
+        sock2.once("data", (d: Buffer) => res(d));
+        setTimeout(() => rej(new Error("no reply")), 2000);
+      });
+      expect(reply[0]).toBe(0x05); // handshake still works
+      sock2.destroy();
+    } finally {
+      await bridge.stop();
+    }
+  });
+
+  it("error emitted on client socket post-accept → destroyed, no unhandled throw", async () => {
+    const { ProxyBridge: PB } = await import("../../src/upstream/proxy-bridge");
+    const log = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    const bridge = new PB({ log });
+    const port = await bridge.start();
+    // Capture the SERVER-side socket (the bridge's end) via a connection spy
+    const serverSockets: net.Socket[] = [];
+    (bridge as any)["server"]?.on?.("connection", (s: net.Socket) => serverSockets.push(s));
+    try {
+      const sock = net.createConnection({ host: "127.0.0.1", port });
+      await new Promise<void>((res, rej) => { sock.on("connect", res); sock.on("error", rej); });
+      await new Promise((r) => setTimeout(r, 50)); // let the server accept + attach the lifetime handler
+      const serverSide = serverSockets[serverSockets.length - 1];
+      expect(serverSide).toBeDefined();
+      // Simulate an ECONNRESET-shaped error on the SERVER-side socket (the one
+      // the bridge owns). Without the lifetime handler this is an unhandled
+      // 'error' event → process crash. Vitest fails on unhandled throws, so
+      // reaching the assertion below proves the handler swallowed it.
+      (serverSide as any).emit("error", Object.assign(new Error("read ECONNRESET"), { code: "ECONNRESET" }));
+      await new Promise((r) => setTimeout(r, 50));
+      expect(serverSide.destroyed).toBe(true);
+    } finally {
+      await bridge.stop();
+    }
+  });
+});


### PR DESCRIPTION
## Bug (live-fire P0)

The first real burst against 0.5.0's proxy-affine bridge **crashed the process**: all 12 requests `TypeError: terminated` + docker restart. Logs: `Error: read ECONNRESET / Unhandled 'error' event on Socket`.

## Root cause

After the SOCKS5 handshake, `readN` removes its own error/close listeners. Between the handshake and the `pipeBoth` setup (while `SocksClient.createConnection` is awaited, and for the remote socket generally), a bridge socket had **no error handler** — Chromium resetting a connection mid-lifecycle fired an unhandled `error` event → Node exits. The mocked unit tests never simulate mid-lifecycle resets, so only live traffic could surface it.

## Fix

Lifetime error handlers (`on("error", () => destroy())`) attached to:
1. the client socket at the very top of `handleConnection` (before any await);
2. the remote socket the moment `createConnection` resolves (before piping).

A mid-lifecycle reset now cleanly destroys the socket; pending `readN` rejects via its own close handling.

## Validation

- **509 tests green** (+2 ECONNRESET regression tests: mid-handshake destroy → bridge survives + still serves; server-side socket error → destroyed, no unhandled throw).
- typecheck clean. `version`/CHANGELOG untouched → 0.5.1 patch.