### PR TITLE
fix(qwen-proxy): undici SOCKS dispatcher — proxy rotation actually works (12/12 live-validated)

### DIFF
--- a/packages/qwen-proxy/package.json
+++ b/packages/qwen-proxy/package.json
@@ -37,8 +37,8 @@
     "better-sqlite3": "^12.11.1",
     "hono": "^4.6.0",
     "socks": "^2.8.9",
-    "socks-proxy-agent": "^10.1.0",
     "tsx": "^4.0.0",
+    "undici": "^7.0.0",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/packages/qwen-proxy/src/pool/proxy-pool.ts
+++ b/packages/qwen-proxy/src/pool/proxy-pool.ts
@@ -1,4 +1,36 @@
-import { SocksProxyAgent } from "socks-proxy-agent";
+import * as tls from "node:tls";
+import { Agent } from "undici";
+import { SocksClient } from "socks";
+import { parseSocksUrl } from "../upstream/proxy-bridge";
+
+/** Build a REAL undici Dispatcher for a SOCKS5 upstream (with creds + TLS).
+ *  socks-proxy-agent's SocksProxyAgent extends agent-base's http.Agent — it
+ *  works with node-fetch/https but NOT with undici's fetch({dispatcher})
+ *  ("TypeError: agent.dispatch is not a function"). This connector does the
+ *  SOCKS5 handshake via SocksClient, then wraps https in tls.connect so
+ *  undici gets a proper TLS socket. */
+function makeSocksDispatcher(proxyKey: string): Agent {
+  const upstream = parseSocksUrl(proxyKey);
+  return new Agent({
+    connect: ((opts: any, cb: (err: Error | null, socket?: any) => void) => {
+      const port = Number(opts.port) || (String(opts.protocol ?? "https:") === "https:" ? 443 : 80);
+      SocksClient.createConnection({
+        command: "connect",
+        proxy: { host: upstream.host, port: upstream.port, type: 5, userId: upstream.user, password: upstream.pass },
+        destination: { host: opts.hostname, port },
+        timeout: 10_000,
+      }).then(({ socket }: { socket: any }) => {
+        if (String(opts.protocol ?? "https:") === "https:") {
+          const tlsSock = tls.connect({ socket, servername: opts.hostname, ALPNProtocols: ["http/1.1"] });
+          tlsSock.once("secureConnect", () => cb(null, tlsSock));
+          tlsSock.once("error", (e: Error) => cb(e));
+        } else {
+          cb(null, socket);
+        }
+      }).catch((e: Error) => cb(e));
+    }) as any,
+  });
+}
 
 // ── normalizeSocksUrl ───────────────────────────────────────────────────────
 
@@ -91,7 +123,7 @@ export class ProxyPool {
 // ── ProxyDispatcherCache ─────────────────────────────────────────────────────
 
 export interface DispatcherLike {
-  // Minimal interface for undici Dispatcher — socks-proxy-agent returns SocksProxyAgent
+  // Minimal interface for an undici Dispatcher
   // which implements undici.Dispatcher. We type it loosely to avoid importing undici types.
   [key: string]: unknown;
 }
@@ -101,7 +133,7 @@ export class ProxyDispatcherCache {
   private readonly agentFactory: (key: string) => DispatcherLike;
 
   constructor(opts?: { agentFactory?: (key: string) => DispatcherLike }) {
-    this.agentFactory = opts?.agentFactory ?? ((key: string) => new SocksProxyAgent(key) as unknown as DispatcherLike);
+    this.agentFactory = opts?.agentFactory ?? ((key: string) => makeSocksDispatcher(key) as unknown as DispatcherLike);
   }
 
   get(key: string): DispatcherLike {

--- a/packages/qwen-proxy/src/pool/retry.ts
+++ b/packages/qwen-proxy/src/pool/retry.ts
@@ -76,12 +76,20 @@ export async function withPoolRetry<T>(
       // Rotation mode: rotate on rotatable errors (pre-first-content budget)
       if (rotationMode && isRotationTrigger(err)) {
         tried++;
+        deps.log.warn("[rotation-debug] attempt failed — rotating", {
+          tried,
+          size: deps.proxyPool!.size,
+          error: String(err).slice(0, 300),
+          errorCause: err instanceof Error && err.cause ? String(err.cause).slice(0, 300) : undefined,
+          errorName: err instanceof Error ? err.constructor.name : typeof err,
+        });
         if (tried < deps.proxyPool!.size) {
           deps.proxyPool!.rotate();
           continue;
         }
         // All proxies burned — cooldown + 429
         const { emptyCooldownMs } = deps.config;
+        deps.log.warn("[rotation-debug] ALL burned (non-stream)", { size: deps.proxyPool!.size, lastError: String(err).slice(0, 300) });
         await sleep(emptyCooldownMs);
         throw new RateLimitError(
           "all proxies exhausted after rotation retries",
@@ -195,12 +203,19 @@ export async function* withPoolRetryStream(
       // Rotation mode: rotate on rotatable errors (PRE-first-content ONLY)
       if (rotationMode && !seenContent && isRotationTrigger(err)) {
         tried++;
+        deps.log.warn("[rotation-debug] stream attempt failed — rotating", {
+          tried,
+          size: deps.proxyPool!.size,
+          error: String(err).slice(0, 300),
+          errorCause: err instanceof Error && err.cause ? String(err.cause).slice(0, 300) : undefined,
+          errorName: err instanceof Error ? err.constructor.name : typeof err,
+        });
         if (tried < deps.proxyPool!.size) {
           deps.proxyPool!.rotate();
           continue;
         }
         // All proxies burned — sentinel (no refreshBaxiaToken)
-        deps.log.warn("rotation: all proxies burned (error) — sentinel", { size: deps.proxyPool!.size });
+        deps.log.warn("rotation: all proxies burned (error) — sentinel", { size: deps.proxyPool!.size, lastError: String(err).slice(0, 300) });
         yield { done: true, extra: { rateLimited: true } };
         return;
       }

--- a/packages/qwen-proxy/src/upstream/baxia-token.ts
+++ b/packages/qwen-proxy/src/upstream/baxia-token.ts
@@ -164,8 +164,24 @@ export class BaxiaTokenManager {
       args.unshift(`--proxy-server=${proxyServerUrl}`);
       args.unshift("--host-resolver-rules=MAP * ~NOTFOUND, EXCLUDE 127.0.0.1");
     }
-    const child = this._spawn(exe, args, { stdio: "ignore" });
+    const child = this._spawn(exe, args, { stdio: "ignore", detached: true });
     return { child, port };
+  }
+
+  /** Kill the whole Chromium process TREE (not just the main pid). Spawned
+   *  with detached:true so the browser forms its own process group; killing
+   *  -pid takes down every subprocess. Without this, SIGKILLing only the main
+   *  pid orphans the renderer/gpu/pad children → zombie accumulation under
+   *  node-as-PID-1 (observed: 79-207 chrome procs after a few spawns). */
+  private killChromeTree(child: { pid?: number; kill?: (s?: string) => void }): void {
+    // Guard: never group-kill pid 1 (in unit tests the mocked spawn returns
+    // pid:1 — process.kill(-1) would kill the TEST process group itself).
+    try {
+      if (child.pid && child.pid > 1) process.kill(-child.pid, "SIGKILL"); // negative pid = process group
+      else child.kill?.("SIGKILL");
+    } catch {
+      try { child.kill?.("SIGKILL"); } catch { /* already dead */ }
+    }
   }
 
   // ── cdpConnect ──────────────────────────────────────────────────────────
@@ -257,6 +273,12 @@ export class BaxiaTokenManager {
       ? `socks5://127.0.0.1:${this.bridge.getPort()}`
       : undefined;
     const { child, port } = this.startChrome(exe, proxyServerUrl);
+    this.config.log.info("[baxia-debug] chromium spawn", {
+      proxy: proxy ?? "(direct)",
+      pid: child.pid,
+      port,
+      via: proxyServerUrl ?? "direct",
+    });
 
     try {
       // Wait for Chrome to start /json/list endpoint
@@ -318,9 +340,22 @@ export class BaxiaTokenManager {
         let baxiaData:
           | { uid: string; fy: string; cookies: string }
           | null = null;
+        let lastPageState = "";
         for (let i = 0; i < 60; i++) {
           await this._sleep(500); // sleep first (qwen2api ordering — lets the SDK init)
           try {
+            // Every 10th poll (~5s), capture the page state — reveals CAPTCHA
+            // interstitials / error pages / wrong-language redirects instantly.
+            if (i % 10 === 0) {
+              try {
+                const st = await cdp.send("Runtime.evaluate", {
+                  expression: "JSON.stringify({href: location.href, title: document.title, bodyLen: document.body ? document.body.innerHTML.length : 0, hasBaxia: !!(window.__baxia__ && window.__baxia__.getFYModule)})",
+                  returnByValue: true,
+                });
+                lastPageState = String((st?.result?.value as string) ?? "");
+                this.config.log.warn("[baxia-debug] readiness poll", { poll: i, page: lastPageState.slice(0, 300) });
+              } catch { /* page evaluating mid-nav */ }
+            }
             const result = await cdp.send("Runtime.evaluate", {
               expression: baxiaExpr,
               returnByValue: true,
@@ -352,10 +387,21 @@ export class BaxiaTokenManager {
         }
 
         if (!baxiaData) {
+          this.config.log.error("[baxia-debug] readiness FAILED after 30s", {
+            proxy: proxy ?? "(direct)",
+            lastPage: lastPageState.slice(0, 300),
+          });
           throw new Error(
             "window.__baxia__ tokens not available within 30s",
           );
         }
+        this.config.log.info("[baxia-debug] token minted", {
+          proxy: proxy ?? "(direct)",
+          uidPrefix: baxiaData.uid.slice(0, 8),
+          uidLen: baxiaData.uid.length,
+          fyLen: baxiaData.fy.length,
+          cookieLen: baxiaData.cookies.length,
+        });
 
         return {
           bxUa: baxiaData.fy || "231!" + baxiaData.uid,
@@ -367,11 +413,7 @@ export class BaxiaTokenManager {
         await cdp.close();
       }
     } finally {
-      try {
-        child.kill("SIGKILL");
-      } catch {
-        // best-effort
-      }
+      this.killChromeTree(child);
     }
   }
 

--- a/packages/qwen-proxy/src/upstream/guest-client.ts
+++ b/packages/qwen-proxy/src/upstream/guest-client.ts
@@ -132,19 +132,22 @@ export class GuestUpstreamClient {
       if (!res.ok) {
         if (res.status >= 400 && res.status < 500) {
           const text = await res.text().catch(() => "");
+          this.log.warn("[guest-debug] createChatSession NON-OK", { status: res.status, proxy: proxy ?? "(direct)", body: text.slice(0, 200) });
           throw new ClientError(`createChatSession upstream error ${res.status}: ${text.slice(0, 300)}`, { status: res.status });
         }
         if (res.status >= 500) {
           const text = await res.text().catch(() => "");
+          this.log.warn("[guest-debug] createChatSession NON-OK", { status: res.status, proxy: proxy ?? "(direct)", body: text.slice(0, 200) });
           throw new ServerError(`createChatSession upstream error ${res.status}: ${text.slice(0, 300)}`, { status: res.status });
         }
       }
+      this.log.info("[guest-debug] createChatSession OK", { proxy: proxy ?? "(direct)" });
 
       const data = await res.json();
 
       // Check for rgv587 (Baxia captcha rejection)
       if (RGV587_RE.test(JSON.stringify(data))) {
-        this.log.warn("createChatSession rgv587 detected, retrying", { attempt: attempt + 1 });
+        this.log.warn("createChatSession rgv587 detected, retrying", { attempt: attempt + 1, proxy: proxy ?? "(direct)" });
         if (attempt < maxRetries - 1) {
           await this._sleep(600);
           continue;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -342,12 +342,12 @@ importers:
       socks:
         specifier: ^2.8.9
         version: 2.8.9
-      socks-proxy-agent:
-        specifier: ^10.1.0
-        version: 10.1.0
       tsx:
         specifier: ^4.0.0
         version: 4.22.4
+      undici:
+        specifier: ^7.0.0
+        version: 7.26.0
       zod:
         specifier: ^3.23.0
         version: 3.25.76


### PR DESCRIPTION
## Root cause (found via live instrumentation)

Every proxied completion fetch since 0.4.0 threw instantly: `TypeError: agent.dispatch is not a function`. `socks-proxy-agent`'s SocksProxyAgent extends agent-base's http.Agent — it is **not an undici Dispatcher**, so `fetch({dispatcher})` never worked. Requests never left mini; the token/IP-mismatch fix (0.5.0's bridge) was never actually being exercised.

## Fix

- **`makeSocksDispatcher()`** — a real undici `Agent` with a SOCKS5+TLS connector (`socks` pkg `SocksClient` + `tls.connect` for https, ALPN http/1.1). Per-proxy dispatchers in `ProxyDispatcherCache`; completions connect directly to the NordVPN SOCKS with creds. `socks-proxy-agent` dep removed (unused). `undici` added.
- **`killChromeTree()`** — detached spawn + process-group SIGKILL (Chromium subprocess trees no longer orphan; + `init: true` in compose reaps the residual zombies — deployed on mini).
- **Instrumentation** — underlying rotation error + `error.cause`, per-proxy mint lifecycle, readiness page-state (incl. `hasBaxia`), session-create status per proxy.

## Live validation (mini, NordVPN rotation, size=10)

- Single request: bridge-minted **proxy-affine token ACCEPTED by Baxia** (`createChatSession OK`, no rgv587) → `pong` streamed through the NordVPN egress.
- **Two consecutive 12/12 bursts** (single-IP ceiling was 10/12; qwen2api-on-Netlify parity).
- Zombies: 99 → 1 (reaped) after `init: true`.

## Tests

509 green (typecheck clean) — verified in a Node 22 container on mini (local network was unavailable).