### PR TITLE
fix(qwen-proxy): silence Chromium telemetry in bridge spawns (SOCKS auth-throttle mitigation)

### DIFF
--- a/packages/qwen-proxy/src/upstream/baxia-token.ts
+++ b/packages/qwen-proxy/src/upstream/baxia-token.ts
@@ -153,6 +153,21 @@ export class BaxiaTokenManager {
       "--disable-gpu",
       "--disable-dev-shm-usage",
       "--disable-extensions",
+      // Kill Chromium telemetry/background traffic — each CONNECT through the
+      // SOCKS bridge is a full SOCKS5 auth handshake against NordVPN, and
+      // Google/telemetry beacons were >50% of all handshakes (observed live:
+      // 76 Google/* vs 42 chat.qwen.ai in one hour), tripping NordVPN's
+      // per-server credential throttle ("User was rejected by the SOCKS5
+      // server"). These flags stop the phone-home; only page-essential
+      // traffic remains.
+      "--disable-background-networking",
+      "--disable-component-update",
+      "--disable-sync",
+      "--disable-domain-reliability",
+      "--no-pings",
+      "--disable-breakpad",
+      "--disable-client-side-phishing-detection",
+      "--disable-features=OptimizationGuideModelDownloading,OptimizationHintsFetching,OptimizationTargetPrediction,MediaRouter",
       `--remote-debugging-port=${port}`,
       `--user-data-dir=${userDataDir}`,
       "--window-size=1280,800",


### PR DESCRIPTION
## Root cause of the proxy errors (live-debugged on mini)

`Socks5 Authentication failed` / `User was rejected by the SOCKS5 server` on 5 of 10 NordVPN SOCKS servers: **NordVPN per-server credential throttling**. Every bridge CONNECT is a full SOCKS5 auth handshake, and each Chromium spawn fires 30-60 of them. Measured live: **>50% of all handshakes were Chromium phone-home noise** (76 Google/* vs 42 chat.qwen.ai CONNECTs in one hour) — bursts of spawns hammered each server with hundreds of auths and tripped the throttle.

## Fix

Standard telemetry-silencing flags on the Baxia Chromium spawn (`--disable-background-networking`, `--disable-component-update`, `--disable-sync`, `--disable-domain-reliability`, `--no-pings`, `--disable-breakpad`, `--disable-client-side-phishing-detection`, OptimizationGuide feature-disables) so only page-essential connections reach the bridge.

## Live validation (mini)

- Google-host bridge failures: **31 → 0** after deploy.
- Total bridge failures per request window: dozens → **1**.
- Request path: `pong` end-to-end (proxy-affine token, accepted).
- The throttled servers recover on NordVPN's side with time; with telemetry silenced, auth volume drops >50%, making re-tripping far less likely.

## Tests

509 green, typecheck clean (verified in a Node 22 container on mini).