### PR TITLE
fix(qwen-proxy): proxy-rotation burn dynamics — token eviction, inline re-mint, stall guards, spread, redacted logs

### DIFF
--- a/docs-site/packages/qwen-proxy-docker.md
+++ b/docs-site/packages/qwen-proxy-docker.md
@@ -191,6 +191,8 @@ All configuration is via environment variables (prefix `SF_QWEN_`). Set them in 
 | `SF_QWEN_PROXY_PASS` | *(unset)* | NordVPN service password |
 | `SF_QWEN_PROXY_COUNTRIES` | *(unset)* | Comma-separated country codes for auto-discovery (e.g. `us,de,gb`) |
 | `SF_QWEN_TIMEOUT_MS` | `60000` | TTFB timeout in ms — aborts if no response headers arrive within this window (cleared on headers, never aborts mid-stream) |
+| `SF_QWEN_FIRST_PAYLOAD_TIMEOUT_MS` | `30000` | Abort an upstream completion that produces no payload chunk within this many ms after headers (`0` disables). The abort throws EmptyCompletionError → token eviction + proxy rotation, and always releases the concurrency slot |
+| `SF_QWEN_STREAM_IDLE_TIMEOUT_MS` | `30000` | Abort an upstream stream that goes silent for this many ms after content started flowing (`0` disables). Ends the response gracefully with the partial content — no token eviction |
 | `SF_QWEN_MODEL_ALIASES` | *(unset)* | JSON object mapping alias → upstream model |
 | `SF_QWEN_LOG_LEVEL` | `info` | Log level |
 | `SF_QWEN_CHROME_PATH` | *(unset)* | Path to Chrome/Chromium; unset → autodetect (`/usr/bin/chromium` in Docker) |

--- a/docs-site/packages/qwen-proxy.md
+++ b/docs-site/packages/qwen-proxy.md
@@ -139,6 +139,8 @@ All configuration is via environment variables (prefix `SF_QWEN_`).
 | `SF_QWEN_PROXY_PASS` | *(unset)* | NordVPN service password |
 | `SF_QWEN_PROXY_COUNTRIES` | *(unset)* | Comma-separated country codes for auto-discovery (e.g. `us,de,gb`) |
 | `SF_QWEN_TIMEOUT_MS` | `60000` | TTFB timeout in ms (cleared on headers, never aborts mid-stream) |
+| `SF_QWEN_FIRST_PAYLOAD_TIMEOUT_MS` | `30000` | Abort an upstream completion that produces no payload chunk within this many ms after headers (`0` disables). The abort throws EmptyCompletionError → token eviction + proxy rotation, and always releases the concurrency slot |
+| `SF_QWEN_STREAM_IDLE_TIMEOUT_MS` | `30000` | Abort an upstream stream that goes silent for this many ms after content started flowing (`0` disables). Ends the response gracefully with the partial content — no token eviction |
 
 ### Model aliases
 

--- a/packages/qwen-proxy/README.md
+++ b/packages/qwen-proxy/README.md
@@ -67,6 +67,8 @@ All configuration is via environment variables (prefix `SF_QWEN_`).
 | `SF_QWEN_PROXY_PASS` | *(unset)* | NordVPN service password |
 | `SF_QWEN_PROXY_COUNTRIES` | *(unset)* | Comma-separated country codes for auto-discovery (e.g. `us,de,gb`) |
 | `SF_QWEN_TIMEOUT_MS` | `60000` | TTFB timeout in ms — aborts if no response headers arrive within this window (cleared on headers, never aborts mid-stream) |
+| `SF_QWEN_FIRST_PAYLOAD_TIMEOUT_MS` | `30000` | Abort an upstream completion that produces no payload chunk within this many ms after headers (`0` disables). The abort throws EmptyCompletionError → token eviction + proxy rotation, and always releases the concurrency slot |
+| `SF_QWEN_STREAM_IDLE_TIMEOUT_MS` | `30000` | Abort an upstream stream that goes silent for this many ms after content started flowing (`0` disables). Ends the response gracefully with the partial content — no token eviction |
 | `SF_QWEN_MODEL_ALIASES` | *(unset)* | JSON object mapping alias → upstream model |
 | `SF_QWEN_LOG_LEVEL` | `info` | Log level |
 | `SF_QWEN_CHROME_PATH` | *(unset)* | Path to Chrome/Chromium; unset → autodetect (`/usr/bin/chromium` in Docker) |

--- a/packages/qwen-proxy/bin/qwen-proxy.ts
+++ b/packages/qwen-proxy/bin/qwen-proxy.ts
@@ -72,10 +72,19 @@ async function main() {
     }
 
     // Pre-warm: eagerly fetch the first token so the server starts ready.
-    // In rotation mode (bridge set), skip pre-warm — the lazy on-demand refresh
-    // handles the first proxy's token when the first request arrives. Pre-warming
-    // with no proxy would mint a DIRECT_KEY token via direct Chromium (wasteful).
-    if (config.baxia.preWarm && !bridge) {
+    // Non-rotation (direct Chromium): exit 1 on failure — the first request
+    // would be equally broken. Rotation mode (bridge set): pre-mint the ACTIVE
+    // proxy's token under the SAME SF_QWEN_BAXIA_PRE_WARM flag (Q5 — no new
+    // knob), but a failure only logs: lazy on-demand re-mint self-heals, and one
+    // Nord server hiccup at boot must not kill the service.
+    if (config.baxia.preWarm && bridge && proxyPool && proxyPool.size > 0) {
+      try {
+        await baxia.ensureToken({ proxy: proxyPool.getActive() });
+        log.info("baxia pre-warm succeeded (rotation)");
+      } catch (e) {
+        log.error("baxia rotation pre-warm failed — continuing (lazy mint on first request)", { error: String(e) });
+      }
+    } else if (config.baxia.preWarm && !bridge) {
       try {
         await baxia.ensureToken();
         log.info("baxia pre-warm succeeded");
@@ -91,12 +100,15 @@ async function main() {
     // Cap concurrent chat.qwen.ai calls — Baxia flags the IP on concurrent
     // upstream connections. Default 1 (serialize, like the web chat); tune with SF_QWEN_MAX_CONCURRENCY.
     const concurrency = new Semaphore(config.maxConcurrency);
-    const client = new GuestUpstreamClient({ baxia, chatUrl: CHAT_URL, concurrency, log, proxyDispatcherCache, timeoutMs: config.timeoutMs });
-
-    // Re-create client with proxy dispatcher cache + timeout if rotation enabled
-    const finalClient = proxyDispatcherCache
-      ? new GuestUpstreamClient({ baxia, chatUrl: CHAT_URL, concurrency, log, proxyDispatcherCache, timeoutMs: config.timeoutMs })
-      : client;
+    const client = new GuestUpstreamClient({
+      baxia, chatUrl: CHAT_URL, concurrency, log,
+      timeoutMs: config.timeoutMs,
+      ...(proxyDispatcherCache ? { proxyDispatcherCache } : {}),
+      stallGuard: {
+        firstPayloadTimeoutMs: config.firstPayloadTimeoutMs,
+        idleTimeoutMs: config.streamIdleTimeoutMs,
+      },
+    });
 
     // Single-account pool shim (guest mode: one virtual account, no failover)
     const pool = new SingleAccountPool({ log });
@@ -104,14 +116,22 @@ async function main() {
     // No-op auth scheduler (guest has no JWT to refresh)
     const scheduler = {
       refreshOnDemand: async () => ({ bearer: "guest", expiresAt: null }),
-      // Rotate the Baxia token on empty-exhaustion: in guest mode the token/session
-      // can get flagged by Baxia, and a fresh Chromium spawn recovers it without a restart.
-      // When a proxyPool exists, thread the active proxy so the refresh targets
-      // the proxy's cache entry (not DIRECT_KEY). Without this, size===1 proxy setups
-      // would refresh direct-Chromium's token instead of the proxy's → stale token.
-      refreshBaxiaToken: async () => {
-        const proxy = proxyPool?.getActive();
-        await baxia.ensureToken({ forceRefresh: true, ...(proxy ? { proxy } : {}) });
+      // Force-refresh a proxy's Baxia token (defaults to the active proxy).
+      // Burn-dynamics: called for the ≤1 inline re-mint on empty and at the
+      // all-burned sentinel so the next request self-recovers without a restart.
+      refreshBaxiaToken: async (proxy?: string) => {
+        const p = proxy ?? proxyPool?.getActive();
+        await baxia.ensureToken({ forceRefresh: true, ...(p ? { proxy: p } : {}) });
+      },
+      // Mark a proxy's token burned (evicts cache + logs requestsServed).
+      evictBaxiaToken: (proxy?: string) => {
+        baxia.evictToken(proxy ?? proxyPool?.getActive());
+      },
+      // Cached-token age for empty-walk logging.
+      baxiaTokenAgeMs: (proxy?: string) => {
+        const p = proxy ?? proxyPool?.getActive();
+        if (!p) return baxia.status().ageMs;
+        return baxia.proxyStatuses()[p]?.ageMs ?? null;
       },
     };
 
@@ -123,7 +143,7 @@ async function main() {
     const deps: AppDeps = {
       db,
       pool,
-      client: finalClient,
+      client,
       scheduler,
       config,
       retry: withPoolRetry,

--- a/packages/qwen-proxy/docker/README.md
+++ b/packages/qwen-proxy/docker/README.md
@@ -174,6 +174,8 @@ All configuration is via environment variables (prefix `SF_QWEN_`), set automati
 | `SF_QWEN_PROXY_PASS` | *(unset)* | NordVPN service password |
 | `SF_QWEN_PROXY_COUNTRIES` | *(unset)* | Comma-separated country codes for auto-discovery (e.g. `us,de,gb`) |
 | `SF_QWEN_TIMEOUT_MS` | `60000` | TTFB timeout in ms — aborts if no response headers arrive within this window (cleared on headers, never aborts mid-stream) |
+| `SF_QWEN_FIRST_PAYLOAD_TIMEOUT_MS` | `30000` | Abort an upstream completion that produces no payload chunk within this many ms after headers (`0` disables). The abort throws EmptyCompletionError → token eviction + proxy rotation, and always releases the concurrency slot |
+| `SF_QWEN_STREAM_IDLE_TIMEOUT_MS` | `30000` | Abort an upstream stream that goes silent for this many ms after content started flowing (`0` disables). Ends the response gracefully with the partial content — no token eviction |
 | `SF_QWEN_MODEL_ALIASES` | *(unset)* | JSON object mapping alias → upstream model |
 | `SF_QWEN_LOG_LEVEL` | `info` | Log level |
 | `SF_QWEN_CHROME_PATH` | *(unset)* | Path to Chrome/Chromium; unset → autodetect (`/usr/bin/chromium` in Docker) |

--- a/packages/qwen-proxy/docker/README.md
+++ b/packages/qwen-proxy/docker/README.md
@@ -145,6 +145,8 @@ services:
       # - SF_QWEN_ADMIN_KEY=${SF_QWEN_ADMIN_KEY}
       # - SF_QWEN_BAXIA_CACHE_TTL_MS=1500000
       # - SF_QWEN_BAXIA_PRE_WARM=true
+      # - SF_QWEN_FIRST_PAYLOAD_TIMEOUT_MS=30000
+      # - SF_QWEN_STREAM_IDLE_TIMEOUT_MS=30000
     restart: unless-stopped
     # healthcheck lives in the Dockerfile
 

--- a/packages/qwen-proxy/src/config/load.ts
+++ b/packages/qwen-proxy/src/config/load.ts
@@ -33,6 +33,8 @@ export async function loadQwenProxyConfig(
     proxyPass: env.SF_QWEN_PROXY_PASS || undefined,
     proxyCountriesRaw: env.SF_QWEN_PROXY_COUNTRIES || "",
     timeoutMs: parseIntEnv(env.SF_QWEN_TIMEOUT_MS, 60_000),
+    firstPayloadTimeoutMs: parseNonNegativeIntEnv(env.SF_QWEN_FIRST_PAYLOAD_TIMEOUT_MS, 30_000),
+    streamIdleTimeoutMs: parseNonNegativeIntEnv(env.SF_QWEN_STREAM_IDLE_TIMEOUT_MS, 30_000),
     apiKeyEnv: (env.SF_QWEN_API_KEY || "").split(",").map(s => s.trim()).filter(Boolean),
     modelAliasesRaw: env.SF_QWEN_MODEL_ALIASES || "",
     logLevel: env.SF_QWEN_LOG_LEVEL || "info",

--- a/packages/qwen-proxy/src/config/types.ts
+++ b/packages/qwen-proxy/src/config/types.ts
@@ -21,6 +21,8 @@ export interface QwenProxyConfig {
   proxyPass?: string;         // SF_QWEN_PROXY_PASS           default undefined
   proxyCountriesRaw: string;  // SF_QWEN_PROXY_COUNTRIES      default "" (comma-separated country codes)
   timeoutMs: number;          // SF_QWEN_TIMEOUT_MS           default 60000  (TTFB timeout, ms)
+  firstPayloadTimeoutMs: number; // SF_QWEN_FIRST_PAYLOAD_TIMEOUT_MS default 30000 (abort with EmptyCompletionError if no payload chunk within this many ms after headers; 0 disables)
+  streamIdleTimeoutMs: number;  // SF_QWEN_STREAM_IDLE_TIMEOUT_MS default 30000 (end the stream gracefully if silent this many ms after content started; 0 disables)
   apiKeyEnv: string[];       // SF_QWEN_API_KEY           default []  (comma-split)
   modelAliasesRaw: string;   // SF_QWEN_MODEL_ALIASES     default ""  (JSON object)
   logLevel: string;           // SF_QWEN_LOG_LEVEL            default "info"

--- a/packages/qwen-proxy/src/pool/proxy-pool.ts
+++ b/packages/qwen-proxy/src/pool/proxy-pool.ts
@@ -95,6 +95,11 @@ export function parseProxyUrls(
 export class ProxyPool {
   private readonly keys: string[];
   private head: number;
+  /** Per-proxy serialization ledger: key → held slot (0 = free). Q2=C — assignment
+   *  returns the first FREE slot (sticky-first from head), so concurrency spreads
+   *  and sequential load sticks with no config special-case. */
+  private readonly busy = new Map<string, number>();
+  private readonly slotWaiters: Array<() => void> = [];
 
   constructor(keys: string[]) {
     this.keys = keys;
@@ -117,6 +122,46 @@ export class ProxyPool {
 
   getKeys(): string[] {
     return [...this.keys];
+  }
+
+  private slotFree(key: string): boolean {
+    return (this.busy.get(key) ?? 0) === 0;
+  }
+
+  /** First key with a free slot, STICKY-FIRST from the current head (head's own
+   *  slot first, then wrap-around scan). Sets head to the acquired key so the
+   *  next sequential request reuses it. Blocks FIFO while every slot is busy —
+   *  progress is guaranteed because slots are only held by in-flight or
+   *  queued requests, both of which always complete. pick() and busy.set() run
+   *  in one synchronous stretch after every await, so two woken acquirers can
+   *  never take the same key. */
+  async acquire(): Promise<string> {
+    const pick = (): string | undefined => {
+      for (let i = 0; i < this.keys.length; i++) {
+        const idx = (this.head + i) % this.keys.length;
+        const k = this.keys[idx];
+        if (this.slotFree(k)) {
+          this.head = idx; // stickiness: head follows the acquisition
+          return k;
+        }
+      }
+      return undefined;
+    };
+    let k = pick();
+    while (k === undefined) {
+      await new Promise<void>((resolve) => this.slotWaiters.push(resolve));
+      k = pick();
+    }
+    this.busy.set(k, 1);
+    return k;
+  }
+
+  /** Free the request's slot. Head unchanged — the next sequential request
+   *  sticks to the last-used proxy. Wakes exactly one FIFO waiter. */
+  release(key: string): void {
+    this.busy.set(key, 0);
+    const next = this.slotWaiters.shift();
+    if (next) next();
   }
 }
 

--- a/packages/qwen-proxy/src/pool/retry.ts
+++ b/packages/qwen-proxy/src/pool/retry.ts
@@ -82,8 +82,9 @@ async function rotateWithSlot(deps: RetryDeps, current: string | undefined): Pro
  *  2. evict the proxy's burned token
  *  3. if no inline re-mint happened yet for this request: force re-mint and
  *     retry the SAME proxy (bounded: one per request)
- *  4. else rotate (or signal all-burned when tried >= size)
- *  Returns the next proxy to try, or null when all proxies are burned. */
+ *  4. else rotate (or signal all-burned when the walk budget is spent)
+ *  Returns the next action: remint (retry same proxy), rotate (next proxy),
+ *  or all-burned (sentinel/429 + refresh). */
 async function emptyBurnStep(
   deps: RetryDeps,
   opts: { proxy: string | undefined; tried: number; inlineReminted: boolean },

--- a/packages/qwen-proxy/src/pool/retry.ts
+++ b/packages/qwen-proxy/src/pool/retry.ts
@@ -1,20 +1,31 @@
 import type { OpenAiChatChunk } from "../upstream/client";
 import { RateLimitError, AuthExpiredError, EmptyCompletionError, NetworkError, ServerError, ClientError, UnknownError } from "../upstream/errors";
+import { redactProxyKey } from "../upstream/proxy-bridge";
 import type { PoolLike } from "./types";
 import type { RequestThrottle } from "./throttle";
 
-/** Minimal proxy-pool contract for rotation mode (S-M2). */
+/** Minimal proxy-pool contract for rotation mode (S-M2 + burn-dynamics Q2=C).
+ *  acquire/release are OPTIONAL per-proxy serialization slots: when present the
+ *  retry layer holds one slot per request (sticky-first assignment, spread under
+ *  concurrency); when absent (legacy fakes / non-slot pools) retry falls back to
+ *  sticky getActive() + rotate(). */
 export interface ProxyPoolLike {
   readonly size: number;
   getActive(): string | undefined;
   rotate(): string | undefined;
+  acquire?(): Promise<string>;
+  release?(key: string): void;
 }
 
 /** Minimal scheduler contract retry needs: on-demand token refresh. */
 export interface RetryScheduler {
   refreshOnDemand(id: number): Promise<{ bearer: string; expiresAt: number | null }>;
-  /** Best-effort Baxia token rotation — called on empty-exhaustion so the next request gets a fresh, unflagged token. Optional (absent in tests). */
-  refreshBaxiaToken?(): Promise<void>;
+  /** Force-refresh a proxy's Baxia token (defaults to the active proxy). Optional (absent in tests). */
+  refreshBaxiaToken?(proxy?: string): Promise<void>;
+  /** Mark a proxy's Baxia token burned (evict + log requestsServed). Optional (absent in tests). */
+  evictBaxiaToken?(proxy?: string): void;
+  /** Age of the proxy's cached token in ms (for empty-walk logging). Optional (absent in tests). */
+  baxiaTokenAgeMs?(proxy?: string): number | null;
 }
 
 export interface RetryDeps {
@@ -40,6 +51,71 @@ export type StreamChunk =
   | OpenAiChatChunk
   | { done: true; extra?: { rateLimited?: boolean } };
 
+/** Best-effort sentinel refresh; never fatal. */
+async function bestEffortRefresh(
+  deps: RetryDeps,
+  proxy: string | undefined,
+): Promise<void> {
+  try {
+    await deps.scheduler.refreshBaxiaToken?.(proxy);
+  } catch (e) {
+    deps.log.error("baxia token refresh failed after all-burned", { error: String(e), proxy: redactProxyKey(proxy) });
+  }
+}
+
+/** Slot-aware proxy hand-off on rotation: advance the head, acquire the new
+ *  head's slot (sticky-first, skips busy proxies), THEN release the old slot so
+ *  the burned proxy is not handed to another request mid-flight. */
+async function rotateWithSlot(deps: RetryDeps, current: string | undefined): Promise<string | undefined> {
+  const pool = deps.proxyPool!;
+  pool.rotate();
+  if (typeof pool.acquire === "function" && typeof pool.release === "function") {
+    const next = await pool.acquire();
+    if (current !== undefined) pool.release(current);
+    return next;
+  }
+  return pool.getActive();
+}
+
+/** Rotation-mode empty-completion burn recovery (Q1=B):
+ *  1. log the walk attempt (redacted proxy, tried/size, token age)
+ *  2. evict the proxy's burned token
+ *  3. if no inline re-mint happened yet for this request: force re-mint and
+ *     retry the SAME proxy (bounded: one per request)
+ *  4. else rotate (or signal all-burned when tried >= size)
+ *  Returns the next proxy to try, or null when all proxies are burned. */
+async function emptyBurnStep(
+  deps: RetryDeps,
+  opts: { proxy: string | undefined; tried: number; inlineReminted: boolean },
+): Promise<{ action: "remint" } | { action: "rotate"; proxy: string | undefined } | { action: "all-burned" }> {
+  const pool = deps.proxyPool!;
+  deps.log.warn("[rotation-debug] empty completion — walking", {
+    proxy: redactProxyKey(opts.proxy),
+    tried: opts.tried + 1,
+    size: pool.size,
+    tokenAgeMs: opts.proxy ? (deps.scheduler.baxiaTokenAgeMs?.(opts.proxy) ?? null) : null,
+  });
+  if (opts.proxy !== undefined) deps.scheduler.evictBaxiaToken?.(opts.proxy);
+  if (!opts.inlineReminted) {
+    // Inline re-mint on the SAME proxy (bounded once per request) — the egress
+    // IP is usually fine, only the token is burned.
+    try {
+      await deps.scheduler.refreshBaxiaToken?.(opts.proxy);
+    } catch (e) {
+      deps.log.error("baxia inline re-mint failed — rotating", { error: String(e), proxy: redactProxyKey(opts.proxy) });
+      if (opts.tried < pool.size - 1) {
+        return { action: "rotate", proxy: await rotateWithSlot(deps, opts.proxy) };
+      }
+      return { action: "all-burned" };
+    }
+    return { action: "remint" };
+  }
+  if (opts.tried < pool.size - 1) {
+    return { action: "rotate", proxy: await rotateWithSlot(deps, opts.proxy) };
+  }
+  return { action: "all-burned" };
+}
+
 /**
  * Non-stream retry: AuthExpiredError → refresh → retry same.
  * EmptyCompletionError → inline retry (up to emptyRetryMax) → exhaustion sentinel.
@@ -51,13 +127,19 @@ export async function withPoolRetry<T>(
   let authRefreshedFor: number | null = null;
   let emptyRetries = 0;
   const rotationMode = !!(deps.proxyPool && deps.proxyPool.size > 1);
+  const useSlots = !!(deps.proxyPool?.acquire && deps.proxyPool?.release);
   let tried = 0;
+  let inlineReminted = false;
+  let slotKey: string | undefined;
+
+  try {
+    if (useSlots) slotKey = await deps.proxyPool!.acquire!();
 
   while (true) {
     const acct = deps.pool.getActiveAccount();
     const { id, bearer } = acct;
     await deps.throttle?.waitFor(id);
-    const proxy = deps.proxyPool?.getActive();
+    const proxy = slotKey ?? deps.proxyPool?.getActive();
 
     try {
       const result = await op(id, bearer, proxy);
@@ -73,10 +155,35 @@ export async function withPoolRetry<T>(
         throw err;
       }
 
+      // Rotation mode: empty completion → burn recovery (evict + inline re-mint, Q1=B)
+      if (rotationMode && err instanceof EmptyCompletionError) {
+        const step = await emptyBurnStep(deps, { proxy, tried, inlineReminted });
+        if (step.action === "remint") {
+          inlineReminted = true;
+          continue; // retry the SAME proxy with the fresh token
+        }
+        if (step.action === "rotate") {
+          tried += 1;
+          slotKey = useSlots ? step.proxy : undefined;
+          continue;
+        }
+        // All proxies burned — cooldown + refresh active token (change #2, Q3=A) + 429
+        tried += 1;
+        const { emptyCooldownMs } = deps.config;
+        deps.log.warn("[rotation-debug] ALL burned (non-stream)", { size: deps.proxyPool!.size, lastError: String(err).slice(0, 300) });
+        await sleep(emptyCooldownMs);
+        await bestEffortRefresh(deps, proxy);
+        throw new RateLimitError(
+          "all proxies exhausted after rotation retries",
+          { status: 429, retryAfterMs: emptyCooldownMs },
+        );
+      }
+
       // Rotation mode: rotate on rotatable errors (pre-first-content budget)
       if (rotationMode && isRotationTrigger(err)) {
         tried++;
         deps.log.warn("[rotation-debug] attempt failed — rotating", {
+          proxy: redactProxyKey(proxy),
           tried,
           size: deps.proxyPool!.size,
           error: String(err).slice(0, 300),
@@ -84,13 +191,15 @@ export async function withPoolRetry<T>(
           errorName: err instanceof Error ? err.constructor.name : typeof err,
         });
         if (tried < deps.proxyPool!.size) {
-          deps.proxyPool!.rotate();
+          const next = await rotateWithSlot(deps, slotKey ?? proxy);
+          slotKey = useSlots ? next : undefined;
           continue;
         }
-        // All proxies burned — cooldown + 429
+        // All proxies burned — cooldown + refresh active token (change #2) + 429
         const { emptyCooldownMs } = deps.config;
         deps.log.warn("[rotation-debug] ALL burned (non-stream)", { size: deps.proxyPool!.size, lastError: String(err).slice(0, 300) });
         await sleep(emptyCooldownMs);
+        await bestEffortRefresh(deps, proxy);
         throw new RateLimitError(
           "all proxies exhausted after rotation retries",
           { status: 429, retryAfterMs: emptyCooldownMs },
@@ -126,6 +235,11 @@ export async function withPoolRetry<T>(
       throw err;
     }
   }
+  } finally {
+    // Release the per-proxy serialization slot on EVERY exit path (success,
+    // throw, all-burned) — the request owned exactly one slot.
+    if (slotKey !== undefined && useSlots) deps.proxyPool!.release!(slotKey);
+  }
 }
 
 /**
@@ -148,13 +262,19 @@ export async function* withPoolRetryStream(
   let authRefreshedFor: number | null = null;
   let emptyRetries = 0;
   const rotationMode = !!(deps.proxyPool && deps.proxyPool.size > 1);
+  const useSlots = !!(deps.proxyPool?.acquire && deps.proxyPool?.release);
   let tried = 0;
+  let inlineReminted = false;
+  let slotKey: string | undefined;
+
+  try {
+    if (useSlots) slotKey = await deps.proxyPool!.acquire!();
 
   while (true) {
     const acct = deps.pool.getActiveAccount();
     const { id, bearer } = acct;
     await deps.throttle?.waitFor(id);
-    const proxy = deps.proxyPool?.getActive();
+    const proxy = slotKey ?? deps.proxyPool?.getActive();
 
     const buffer: StreamChunk[] = [];
     let seenContent = false;
@@ -204,6 +324,7 @@ export async function* withPoolRetryStream(
       if (rotationMode && !seenContent && isRotationTrigger(err)) {
         tried++;
         deps.log.warn("[rotation-debug] stream attempt failed — rotating", {
+          proxy: redactProxyKey(proxy),
           tried,
           size: deps.proxyPool!.size,
           error: String(err).slice(0, 300),
@@ -211,11 +332,13 @@ export async function* withPoolRetryStream(
           errorName: err instanceof Error ? err.constructor.name : typeof err,
         });
         if (tried < deps.proxyPool!.size) {
-          deps.proxyPool!.rotate();
+          const next = await rotateWithSlot(deps, slotKey ?? proxy);
+          slotKey = useSlots ? next : undefined;
           continue;
         }
-        // All proxies burned — sentinel (no refreshBaxiaToken)
+        // All proxies burned — refresh the active proxy's token (change #2, Q3=A), then sentinel
         deps.log.warn("rotation: all proxies burned (error) — sentinel", { size: deps.proxyPool!.size, lastError: String(err).slice(0, 300) });
+        await bestEffortRefresh(deps, proxy);
         yield { done: true, extra: { rateLimited: true } };
         return;
       }
@@ -224,15 +347,22 @@ export async function* withPoolRetryStream(
       throw err;
     }
 
-    // Rotation mode: empty → rotate (PRE-first-content)
+    // Rotation mode: empty → burn recovery (evict + inline re-mint once → rotate → sentinel)
     if (emptyCompletion && rotationMode) {
-      tried++;
-      if (tried < deps.proxyPool!.size) {
-        deps.proxyPool!.rotate();
+      const step = await emptyBurnStep(deps, { proxy, tried, inlineReminted });
+      if (step.action === "remint") {
+        inlineReminted = true;
+        continue; // retry the SAME proxy with the fresh token
+      }
+      if (step.action === "rotate") {
+        tried += 1;
+        slotKey = useSlots ? step.proxy : undefined;
         continue;
       }
-      // All proxies burned — sentinel (no refreshBaxiaToken)
+      // All proxies burned — refresh the active proxy's token, then sentinel (change #2, Q3=A)
+      tried += 1;
       deps.log.warn("rotation: all proxies burned (empty) — sentinel", { size: deps.proxyPool!.size });
+      await bestEffortRefresh(deps, proxy);
       yield { done: true, extra: { rateLimited: true } };
       return;
     }
@@ -266,6 +396,11 @@ export async function* withPoolRetryStream(
       yield { done: true, extra: { rateLimited: true } };
       return;
     }
+  }
+  } finally {
+    // Release the per-proxy serialization slot on EVERY exit path (clean end,
+    // sentinel, throw, consumer break — the generator's return() lands here).
+    if (slotKey !== undefined && useSlots) deps.proxyPool!.release!(slotKey);
   }
 }
 

--- a/packages/qwen-proxy/src/pool/retry.ts
+++ b/packages/qwen-proxy/src/pool/retry.ts
@@ -157,9 +157,10 @@ export async function withPoolRetry<T>(
 
       // Rotation mode: empty completion → burn recovery (evict + inline re-mint, Q1=B)
       if (rotationMode && err instanceof EmptyCompletionError) {
+        const allowRemint = !inlineReminted;
         const step = await emptyBurnStep(deps, { proxy, tried, inlineReminted });
+        if (allowRemint) inlineReminted = true; // an ATTEMPT consumes the one-per-request allowance
         if (step.action === "remint") {
-          inlineReminted = true;
           continue; // retry the SAME proxy with the fresh token
         }
         if (step.action === "rotate") {
@@ -320,6 +321,28 @@ export async function* withPoolRetryStream(
         throw err;
       }
 
+      // Rotation mode: THROWN EmptyCompletionError pre-first-content (stall-guard
+      // first-payload timeout) → burn recovery (evict + inline re-mint), NOT plain
+      // rotation — otherwise the burned token stays cached (impl-review F1).
+      if (rotationMode && !seenContent && err instanceof EmptyCompletionError) {
+        const allowRemint = !inlineReminted;
+        const step = await emptyBurnStep(deps, { proxy, tried, inlineReminted });
+        if (allowRemint) inlineReminted = true; // an ATTEMPT consumes the one-per-request allowance
+        if (step.action === "remint") {
+          continue; // retry the SAME proxy with the fresh token
+        }
+        if (step.action === "rotate") {
+          tried += 1;
+          slotKey = useSlots ? step.proxy : undefined;
+          continue;
+        }
+        tried += 1;
+        deps.log.warn("rotation: all proxies burned (empty) — sentinel", { size: deps.proxyPool!.size });
+        await bestEffortRefresh(deps, proxy);
+        yield { done: true, extra: { rateLimited: true } };
+        return;
+      }
+
       // Rotation mode: rotate on rotatable errors (PRE-first-content ONLY)
       if (rotationMode && !seenContent && isRotationTrigger(err)) {
         tried++;
@@ -349,9 +372,10 @@ export async function* withPoolRetryStream(
 
     // Rotation mode: empty → burn recovery (evict + inline re-mint once → rotate → sentinel)
     if (emptyCompletion && rotationMode) {
+      const allowRemint = !inlineReminted;
       const step = await emptyBurnStep(deps, { proxy, tried, inlineReminted });
+      if (allowRemint) inlineReminted = true; // an ATTEMPT consumes the one-per-request allowance
       if (step.action === "remint") {
-        inlineReminted = true;
         continue; // retry the SAME proxy with the fresh token
       }
       if (step.action === "rotate") {

--- a/packages/qwen-proxy/src/upstream/baxia-token.ts
+++ b/packages/qwen-proxy/src/upstream/baxia-token.ts
@@ -9,6 +9,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { spawn as nodeSpawn } from "node:child_process";
 import { NetworkError } from "./errors";
+import { redactProxyKey } from "./proxy-bridge";
 import type { Logger } from "../server/logger";
 
 // ── Public types ────────────────────────────────────────────────────────────
@@ -45,6 +46,8 @@ export interface BaxiaStatus {
   nextRefreshInMs: number | null;
   lastSpawnDurationMs: number | null;
   consecutiveFailures: number;
+  /** Completed requests served through the currently-cached token (reset on each mint). */
+  requestsServed: number;
 }
 
 // ── CDP session ─────────────────────────────────────────────────────────────
@@ -85,7 +88,7 @@ export class BaxiaTokenManager {
   private _sleep: (ms: number) => Promise<void>;
 
   // Orchestration state
-  private proxyCache = new Map<string, { tokens: BaxiaTokens | null; cachedAt: number | null; lastSpawnDurationMs: number | null; consecutiveFailures: number }>();
+  private proxyCache = new Map<string, { tokens: BaxiaTokens | null; cachedAt: number | null; lastSpawnDurationMs: number | null; consecutiveFailures: number; requestsServed: number }>();
   private pendingByProxy = new Map<string, Promise<BaxiaTokens>>();
   private lastUsedProxy: string = "";
   private refreshTimer: ReturnType<typeof setInterval> | null = null;
@@ -289,7 +292,7 @@ export class BaxiaTokenManager {
       : undefined;
     const { child, port } = this.startChrome(exe, proxyServerUrl);
     this.config.log.info("[baxia-debug] chromium spawn", {
-      proxy: proxy ?? "(direct)",
+      proxy: redactProxyKey(proxy),
       pid: child.pid,
       port,
       via: proxyServerUrl ?? "direct",
@@ -403,7 +406,7 @@ export class BaxiaTokenManager {
 
         if (!baxiaData) {
           this.config.log.error("[baxia-debug] readiness FAILED after 30s", {
-            proxy: proxy ?? "(direct)",
+            proxy: redactProxyKey(proxy),
             lastPage: lastPageState.slice(0, 300),
           });
           throw new Error(
@@ -411,7 +414,7 @@ export class BaxiaTokenManager {
           );
         }
         this.config.log.info("[baxia-debug] token minted", {
-          proxy: proxy ?? "(direct)",
+          proxy: redactProxyKey(proxy),
           uidPrefix: baxiaData.uid.slice(0, 8),
           uidLen: baxiaData.uid.length,
           fyLen: baxiaData.fy.length,
@@ -465,6 +468,34 @@ export class BaxiaTokenManager {
     }
   }
 
+  /** Count a completed request against the proxy's currently-cached token (change #7). No-op when no entry. */
+  recordRequestServed(proxy?: string): void {
+    const key = proxy ?? BaxiaTokenManager.DIRECT_KEY;
+    const entry = this.proxyCache.get(key);
+    if (entry) entry.requestsServed += 1;
+  }
+
+  /** Mark the proxy's cached token burned: drop it so the next ensureToken re-mints.
+   *  Logs the measured requests-served count (change #1 + #7). */
+  evictToken(proxy?: string): void {
+    const key = proxy ?? BaxiaTokenManager.DIRECT_KEY;
+    const entry = this.proxyCache.get(key);
+    if (!entry) return;
+    const now = this.config.now?.() ?? Date.now();
+    this.config.log.warn("[baxia] token burned — evicting", {
+      proxy: redactProxyKey(proxy),
+      requestsServed: entry.requestsServed,
+      ageMs: entry.cachedAt != null ? now - entry.cachedAt : null,
+    });
+    this.proxyCache.set(key, {
+      tokens: null,
+      cachedAt: null,
+      lastSpawnDurationMs: null,
+      consecutiveFailures: entry.consecutiveFailures,
+      requestsServed: 0,
+    });
+  }
+
   private async withSpawnLock<T>(fn: () => Promise<T>): Promise<T> {
     // Chain onto spawnChain so new spawns wait for the previous one to settle
     const chained = this.spawnChain.then(fn, fn);
@@ -488,6 +519,7 @@ export class BaxiaTokenManager {
         cachedAt: this.config.now?.() ?? Date.now(),
         lastSpawnDurationMs: (this.config.now?.() ?? Date.now()) - start,
         consecutiveFailures: 0,
+        requestsServed: 0,
       });
       this.lastUsedProxy = key; // SUCCESS only
       return tokens;
@@ -498,6 +530,7 @@ export class BaxiaTokenManager {
         cachedAt: prev?.cachedAt ?? null,
         lastSpawnDurationMs: prev?.lastSpawnDurationMs ?? null,
         consecutiveFailures: (prev?.consecutiveFailures ?? 0) + 1,
+        requestsServed: prev?.requestsServed ?? 0,
       });
       if (this.config.fallback && prev?.tokens) {
         return prev.tokens;
@@ -539,6 +572,7 @@ export class BaxiaTokenManager {
         : null,
       lastSpawnDurationMs: entry?.lastSpawnDurationMs ?? null,
       consecutiveFailures: entry?.consecutiveFailures ?? 0,
+      requestsServed: entry?.requestsServed ?? 0,
     };
   }
 
@@ -556,6 +590,7 @@ export class BaxiaTokenManager {
           : null,
         lastSpawnDurationMs: entry.lastSpawnDurationMs,
         consecutiveFailures: entry.consecutiveFailures,
+        requestsServed: entry.requestsServed,
       };
     }
     return result;

--- a/packages/qwen-proxy/src/upstream/guest-client.ts
+++ b/packages/qwen-proxy/src/upstream/guest-client.ts
@@ -17,6 +17,8 @@ import type {
 import type { Logger } from "../server/logger";
 import type { ProxyDispatcherCache, DispatcherLike } from "../pool/proxy-pool";
 import { fetchWithProxy } from "../pool/proxy-pool";
+import { withStallGuard } from "./stall-guard";
+import { redactProxyKey } from "./proxy-bridge";
 
 // ── Config ────────────────────────────────────────────────────────────────
 
@@ -35,6 +37,8 @@ export interface GuestUpstreamClientConfig {
   concurrency?: { acquire(): Promise<void>; release(): void };
   /** Proxy dispatcher cache for SOCKS5 proxy rotation. Absent = no proxy. */
   proxyDispatcherCache?: ProxyDispatcherCache;
+  /** Shared stall-guard knobs (stream + non-stream). Absent = defaults inside withStallGuard. */
+  stallGuard?: { firstPayloadTimeoutMs?: number; idleTimeoutMs?: number };
 }
 
 const DEFAULT_UA =
@@ -54,6 +58,7 @@ export class GuestUpstreamClient {
   private modelsCache: Model[] | null = null;
   private concurrency?: { acquire(): Promise<void>; release(): void };
   private proxyDispatcherCache?: ProxyDispatcherCache;
+  private readonly stallGuard: { firstPayloadTimeoutMs?: number; idleTimeoutMs?: number };
   private readonly timeoutMs: number;
 
   constructor(config: GuestUpstreamClientConfig) {
@@ -65,6 +70,7 @@ export class GuestUpstreamClient {
     this._sleep = config.sleep ?? ((ms) => new Promise((r) => setTimeout(r, ms)));
     this.concurrency = config.concurrency;
     this.proxyDispatcherCache = config.proxyDispatcherCache;
+    this.stallGuard = config.stallGuard ?? {};
     this.timeoutMs = config.timeoutMs ?? 60_000;
   }
 
@@ -132,22 +138,24 @@ export class GuestUpstreamClient {
       if (!res.ok) {
         if (res.status >= 400 && res.status < 500) {
           const text = await res.text().catch(() => "");
-          this.log.warn("[guest-debug] createChatSession NON-OK", { status: res.status, proxy: proxy ?? "(direct)", body: text.slice(0, 200) });
+          this.log.warn("[guest-debug] createChatSession NON-OK", { status: res.status, proxy: redactProxyKey(proxy), body: text.slice(0, 200) });
           throw new ClientError(`createChatSession upstream error ${res.status}: ${text.slice(0, 300)}`, { status: res.status });
         }
         if (res.status >= 500) {
           const text = await res.text().catch(() => "");
-          this.log.warn("[guest-debug] createChatSession NON-OK", { status: res.status, proxy: proxy ?? "(direct)", body: text.slice(0, 200) });
+          this.log.warn("[guest-debug] createChatSession NON-OK", { status: res.status, proxy: redactProxyKey(proxy), body: text.slice(0, 200) });
           throw new ServerError(`createChatSession upstream error ${res.status}: ${text.slice(0, 300)}`, { status: res.status });
         }
       }
-      this.log.info("[guest-debug] createChatSession OK", { proxy: proxy ?? "(direct)" });
+      this.log.info("[guest-debug] createChatSession OK", { proxy: redactProxyKey(proxy) });
+      // Count the request against this proxy's token (change #7).
+      this.baxia.recordRequestServed(proxy);
 
       const data = await res.json();
 
       // Check for rgv587 (Baxia captcha rejection)
       if (RGV587_RE.test(JSON.stringify(data))) {
-        this.log.warn("createChatSession rgv587 detected, retrying", { attempt: attempt + 1, proxy: proxy ?? "(direct)" });
+        this.log.warn("createChatSession rgv587 detected, retrying", { attempt: attempt + 1, proxy: redactProxyKey(proxy) });
         if (attempt < maxRetries - 1) {
           await this._sleep(600);
           continue;
@@ -227,6 +235,15 @@ export class GuestUpstreamClient {
     };
   }
 
+  /** Translated SSE chunks wrapped in the shared stall guard (Q4: both paths). */
+  private async *guardedSse(res: Response): AsyncGenerator<OpenAiChatChunk> {
+    const body = res.body ?? undefined;
+    yield* withStallGuard(translateQwenSse(body!), body, {
+      firstPayloadTimeoutMs: this.stallGuard.firstPayloadTimeoutMs,
+      idleTimeoutMs: this.stallGuard.idleTimeoutMs,
+    });
+  }
+
   // ── chatCompletions ────────────────────────────────────────────────────
 
   chatCompletions(
@@ -250,7 +267,7 @@ export class GuestUpstreamClient {
       if (!res.body) {
         throw new Error("Response body is null (no stream)");
       }
-      yield* translateQwenSse(res.body);
+      yield* this.guardedSse(res);
     } finally {
       this.concurrency?.release();
     }
@@ -272,7 +289,7 @@ export class GuestUpstreamClient {
       let reasoning = "";
       let usage: any = undefined;
 
-      for await (const chunk of translateQwenSse(res.body)) {
+      for await (const chunk of this.guardedSse(res)) {
         const delta = chunk.choices?.[0]?.delta;
         if (delta?.content) content += delta.content;
         if (delta?.reasoning_content) reasoning += delta.reasoning_content;

--- a/packages/qwen-proxy/src/upstream/proxy-bridge.ts
+++ b/packages/qwen-proxy/src/upstream/proxy-bridge.ts
@@ -39,6 +39,18 @@ export function parseSocksUrl(key: string): ParsedSocksUrl {
   };
 }
 
+/** Log-safe form of a proxy key: host:port only (never credentials). */
+export function redactProxyKey(key: string | undefined): string {
+  if (key === undefined || key === "") return "(direct)";
+  try {
+    const u = new URL(key);
+    if (!u.hostname) return "(unparsed)";
+    return `${u.hostname}:${u.port || "1080"}`;
+  } catch {
+    return "(unparsed)";
+  }
+}
+
 // ── ProxyBridge ─────────────────────────────────────────────────────────────
 
 export interface ProxyBridgeConfig {

--- a/packages/qwen-proxy/src/upstream/stall-guard.ts
+++ b/packages/qwen-proxy/src/upstream/stall-guard.ts
@@ -1,0 +1,105 @@
+/**
+ * Shared stream stall guard (change #3, Q4/Q6).
+ *
+ * Wraps the translated OpenAI chunk stream (the output of translateQwenSse) for
+ * BOTH stream and non-stream completions, holding the raw body handle so a
+ * stalled upstream can always be torn down:
+ *
+ * - First-payload timer (SF_QWEN_FIRST_PAYLOAD_TIMEOUT_MS, default 30s, 0=off):
+ *   armed at guard start, disarmed on the first chunk carrying payload
+ *   (content / reasoning_content / tool_calls). A usage-only chunk does NOT
+ *   disarm it. On fire: cancel the body and throw EmptyCompletionError — the
+ *   retry layer treats that as a rotation trigger, and the guest-client finally
+ *   releases the semaphore slot. Covers "SSE 200 then silence forever".
+ *
+ * - Idle timer (SF_QWEN_STREAM_IDLE_TIMEOUT_MS, default 30s, 0=off): armed only
+ *   after the first payload chunk, reset on every chunk. On fire: cancel the
+ *   body and END GRACEFULLY — the client keeps the partial content, no
+ *   rateLimited sentinel, no token eviction (Q6). In non-stream mode the
+ *   partially-buffered completion is returned as-is.
+ *
+ * The two deadlines never race: before the first payload only the first-payload
+ * timer runs; after it only the idle timer runs.
+ */
+
+import { EmptyCompletionError } from "./errors";
+import type { OpenAiChatChunk } from "./types";
+
+export interface StallGuardOpts {
+  /** ms without a payload chunk after guard start → EmptyCompletionError. 0 disables. */
+  firstPayloadTimeoutMs?: number;
+  /** ms without any chunk after content started → graceful end. 0 disables. */
+  idleTimeoutMs?: number;
+}
+
+/** A chunk carries substantive payload if it has content, reasoning, or tool_calls. */
+function chunkHasPayload(chunk: OpenAiChatChunk): boolean {
+  const delta = chunk.choices?.[0]?.delta;
+  return Boolean(delta && (delta.content || delta.reasoning_content || delta.tool_calls));
+}
+
+export async function* withStallGuard(
+  chunks: AsyncIterable<OpenAiChatChunk>,
+  body: ReadableStream<Uint8Array> | undefined,
+  opts: StallGuardOpts = {},
+): AsyncGenerator<OpenAiChatChunk> {
+  const firstMs = opts.firstPayloadTimeoutMs ?? 30_000;
+  const idleMs = opts.idleTimeoutMs ?? 30_000;
+  const iterator = chunks[Symbol.asyncIterator]();
+
+  let firstTimer: ReturnType<typeof setTimeout> | undefined;
+  let idleTimer: ReturnType<typeof setTimeout> | undefined;
+  let sawPayload = false;
+  let fired: "first" | "idle" | undefined;
+  let resolveFired: () => void = () => {};
+  const firedPromise = new Promise<void>((resolve) => {
+    resolveFired = resolve;
+  });
+
+  const fire = (kind: "first" | "idle"): void => {
+    if (fired) return;
+    fired = kind;
+    void body?.cancel().catch(() => {});
+    resolveFired();
+  };
+
+  if (firstMs > 0) firstTimer = setTimeout(() => fire("first"), firstMs);
+
+  const armIdle = (): void => {
+    if (idleMs <= 0) return;
+    if (idleTimer) clearTimeout(idleTimer);
+    idleTimer = setTimeout(() => fire("idle"), idleMs);
+  };
+
+  try {
+    while (true) {
+      // Race the pending read against the timers — a stalled upstream read
+      // never resolves, so a bare await would hang past the deadline.
+      const next = await Promise.race([iterator.next(), firedPromise]);
+      if (next === undefined || fired) break; // timer fired (or fired mid-yield)
+      if (next.done) break;
+      const chunk = next.value;
+      if (!sawPayload && chunkHasPayload(chunk)) {
+        sawPayload = true;
+        if (firstTimer) {
+          clearTimeout(firstTimer);
+          firstTimer = undefined;
+        }
+      }
+      if (sawPayload) armIdle();
+      yield chunk;
+    }
+
+    if (fired === "first") {
+      throw new EmptyCompletionError(
+        `first payload timeout: no content within ${firstMs}ms (SF_QWEN_FIRST_PAYLOAD_TIMEOUT_MS)`,
+      );
+    }
+    // fired === "idle" or clean exhaustion → graceful end (partial content kept)
+  } finally {
+    if (firstTimer) clearTimeout(firstTimer);
+    if (idleTimer) clearTimeout(idleTimer);
+    void iterator.return?.(undefined).catch(() => {});
+    void body?.cancel().catch(() => {});
+  }
+}

--- a/packages/qwen-proxy/tests/adapters/openai/chat.test.ts
+++ b/packages/qwen-proxy/tests/adapters/openai/chat.test.ts
@@ -1348,10 +1348,11 @@ describe("POST /v1/chat/completions", () => {
     });
 
     expect(res.status).toBe(200);
+    // Q1=B: first empty evicts + inline re-mints and retries the SAME proxy
     expect(seen).toEqual([
       "socks5://u:p@a:1080",
-      "socks5://u:p@b:1080",
+      "socks5://u:p@a:1080",
     ]);
-    expect(pool.rotateCalls).toBe(1);
+    expect(pool.rotateCalls).toBe(0);
   });
 });

--- a/packages/qwen-proxy/tests/config.test.ts
+++ b/packages/qwen-proxy/tests/config.test.ts
@@ -203,6 +203,33 @@ describe("config", () => {
       expect(config.proxyCountriesRaw).toBe("US,DE");
     });
 
+    it("stall guard defaults: firstPayloadTimeoutMs/streamIdleTimeoutMs = 30000", async () => {
+      const config = await loadQwenProxyConfig({});
+      expect(config.firstPayloadTimeoutMs).toBe(30_000);
+      expect(config.streamIdleTimeoutMs).toBe(30_000);
+    });
+
+    it("SF_QWEN_FIRST_PAYLOAD_TIMEOUT_MS=0 disables (0 kept, not defaulted)", async () => {
+      const config = await loadQwenProxyConfig({ SF_QWEN_FIRST_PAYLOAD_TIMEOUT_MS: "0" });
+      expect(config.firstPayloadTimeoutMs).toBe(0);
+    });
+
+    it("SF_QWEN_STREAM_IDLE_TIMEOUT_MS=0 disables (0 kept, not defaulted)", async () => {
+      const config = await loadQwenProxyConfig({ SF_QWEN_STREAM_IDLE_TIMEOUT_MS: "0" });
+      expect(config.streamIdleTimeoutMs).toBe(0);
+    });
+
+    it("SF_QWEN_FIRST_PAYLOAD_TIMEOUT_MS=5000 overrides", async () => {
+      const config = await loadQwenProxyConfig({ SF_QWEN_FIRST_PAYLOAD_TIMEOUT_MS: "5000" });
+      expect(config.firstPayloadTimeoutMs).toBe(5_000);
+    });
+
+    it("garbage/negative stall-guard values fall back to 30000", async () => {
+      const c1 = await loadQwenProxyConfig({ SF_QWEN_FIRST_PAYLOAD_TIMEOUT_MS: "abc", SF_QWEN_STREAM_IDLE_TIMEOUT_MS: "-5" });
+      expect(c1.firstPayloadTimeoutMs).toBe(30_000);
+      expect(c1.streamIdleTimeoutMs).toBe(30_000);
+    });
+
     it("overrides timeoutMs via SF_QWEN_TIMEOUT_MS", async () => {
       const config = await loadQwenProxyConfig({ SF_QWEN_TIMEOUT_MS: "30000" });
       expect(config.timeoutMs).toBe(30_000);

--- a/packages/qwen-proxy/tests/health.test.ts
+++ b/packages/qwen-proxy/tests/health.test.ts
@@ -22,6 +22,8 @@ function makeStubDeps(): AppDeps {
       emptyRetryGapMs: 1_000,
       minRequestGapMs: 0,
       maxConcurrency: 1,
+      firstPayloadTimeoutMs: 30_000,
+      streamIdleTimeoutMs: 30_000,
       apiKeyEnv: ["test-key"],
       modelAliasesRaw: "",
       logLevel: "info",

--- a/packages/qwen-proxy/tests/pool/proxy-pool.test.ts
+++ b/packages/qwen-proxy/tests/pool/proxy-pool.test.ts
@@ -389,3 +389,65 @@ describe("createProxyPool", () => {
     });
   });
 });
+
+// ── per-proxy serialization slots (S-M3-1) ──────────────────────────────────
+
+describe("ProxyPool slots", () => {
+  const K1 = "socks5://u:p@h1:1080";
+  const K2 = "socks5://u:p@h2:1080";
+  const K3 = "socks5://u:p@h3:1080";
+
+  it("sticky: sequential acquire/release returns the same key", async () => {
+    const pool = new ProxyPool([K1, K2, K3]);
+    const a = await pool.acquire();
+    expect(a).toBe(K1);
+    pool.release(a);
+    const b = await pool.acquire();
+    expect(b).toBe(K1); // head slot free → same proxy (avoid extra mints)
+    pool.release(b);
+  });
+
+  it("spread: concurrent acquire lands on distinct proxies", async () => {
+    const pool = new ProxyPool([K1, K2, K3]);
+    const a = await pool.acquire();
+    const b = await pool.acquire();
+    expect(a).toBe(K1);
+    expect(b).toBe(K2); // K1 busy → next free slot
+    expect(pool.getActive()).toBe(K2); // head tracks last acquisition
+    pool.release(a);
+    pool.release(b);
+  });
+
+  it("release then acquire reuses the freed slot (scan wraps from head)", async () => {
+    const pool = new ProxyPool([K1, K2]);
+    const a = await pool.acquire(); // K1, head=K1
+    const b = await pool.acquire(); // K2, head=K2
+    expect(b).toBe(K2);
+    pool.release(a); // K1 free, head stays K2
+    const c = await pool.acquire(); // K2 busy → wraps to K1
+    expect(c).toBe(K1);
+    pool.release(b);
+    pool.release(c);
+  });
+
+  it("all slots busy: acquire blocks FIFO until release", async () => {
+    const pool = new ProxyPool([K1]);
+    const a = await pool.acquire();
+    expect(a).toBe(K1);
+    let resolved = "";
+    const pending = pool.acquire().then((k) => { resolved = k; return k; });
+    await new Promise((r) => setTimeout(r, 20));
+    expect(resolved).toBe(""); // still blocked
+    pool.release(a);
+    const k = await pending;
+    expect(k).toBe(K1);
+  });
+
+  it("getActive/rotate/getKeys/size unchanged by slots", async () => {
+    const pool = new ProxyPool([K1, K2, K3]);
+    expect(pool.size).toBe(3);
+    expect(pool.getKeys()).toEqual([K1, K2, K3]);
+    expect(pool.rotate()).toBe(K2);
+    expect(pool.getActive()).toBe(K2);
+  });
+});

--- a/packages/qwen-proxy/tests/pool/retry.test.ts
+++ b/packages/qwen-proxy/tests/pool/retry.test.ts
@@ -1218,3 +1218,66 @@ describe("withPoolRetryStream — burn recovery (S-M3-4)", () => {
     stalled?.();
   });
 });
+
+// ── impl-review fixes: stream stall eviction + re-mint bound ────────────────
+
+describe("impl-review fixes", () => {
+  const PA = "socks5://u:p@hA:1080";
+  const PB = "socks5://u:p@hB:1080";
+
+  it("F1: stream EmptyCompletionError THROWN pre-content (stall guard) gets eviction + inline re-mint, not plain rotation", async () => {
+    const pool = new FakeSlotPool([PA, PB]);
+    const evicted: Array<string | undefined> = [];
+    const refreshed: Array<string | undefined> = [];
+    const deps = makeDeps({
+      proxyPool: pool,
+      config: { emptyCooldownMs: 10, emptyRetryMax: 99, emptyRetryGapMs: 0 },
+      scheduler: {
+        refreshOnDemand: async () => ({ bearer: "", expiresAt: null }),
+        refreshBaxiaToken: async (proxy?: string) => { refreshed.push(proxy); },
+        evictBaxiaToken: (proxy?: string) => { evicted.push(proxy); },
+      },
+      log: { info: () => {}, warn: () => {}, error: () => {} },
+    });
+    const seen: string[] = [];
+    async function* op(_id: number, _b: string, proxy?: string): AsyncIterable<OpenAiChatChunk> {
+      seen.push(proxy!);
+      if (seen.length === 1) throw new EmptyCompletionError("first payload timeout"); // stall-guard shape
+      yield contentChunk("recovered");
+      yield finishChunk("stop");
+    }
+    const chunks = await collectChunks(withPoolRetryStream(deps, op));
+    expect(seen).toEqual([PA, PA]); // retried the SAME proxy after re-mint
+    expect(evicted).toEqual([PA]);
+    expect(refreshed).toEqual([PA]);
+    expect(pool.rotateCalls).toBe(0);
+    expect(chunks[0]).toEqual(contentChunk("recovered"));
+  });
+
+  it("F2: failed inline re-mint consumes the one-per-request allowance (no second mint on later proxies)", async () => {
+    const pool = new FakeSlotPool([PA, PB]);
+    const refreshed: Array<string | undefined> = [];
+    const deps = makeDeps({
+      proxyPool: pool,
+      config: { emptyCooldownMs: 10, emptyRetryMax: 99, emptyRetryGapMs: 0 },
+      scheduler: {
+        refreshOnDemand: async () => ({ bearer: "", expiresAt: null }),
+        refreshBaxiaToken: async (proxy?: string) => { refreshed.push(proxy); throw new Error("chrome spawn failed"); },
+        evictBaxiaToken: () => {},
+      },
+      log: { info: () => {}, warn: () => {}, error: () => {} },
+    });
+    const seen: string[] = [];
+    async function* op(_id: number, _b: string, proxy?: string): AsyncIterable<OpenAiChatChunk> {
+      seen.push(proxy!);
+      yield finishChunk("stop"); // always empty
+    }
+    const chunks = await collectChunks(withPoolRetryStream(deps, op));
+    expect(seen).toEqual([PA, PB]); // remint attempt failed on A → rotate to B directly
+    // Bound held: exactly ONE inline mint attempt on A (no re-attempt after rotation);
+    // the second refresh below is the all-burned SENTINEL refresh of B (change #2), not a re-mint.
+    expect(refreshed).toEqual([PA, PB]);
+    expect(refreshed.filter((p) => p === PA).length).toBe(1);
+    expect((chunks[0] as any).done).toBe(true); // all burned → sentinel
+  });
+});

--- a/packages/qwen-proxy/tests/pool/retry.test.ts
+++ b/packages/qwen-proxy/tests/pool/retry.test.ts
@@ -185,9 +185,18 @@ class FakeProxyPool implements ProxyPoolLike {
 }
 
 describe("withPoolRetry — rotation mode", () => {
-  it("empty → rotate → success (op sees proxy A then B)", async () => {
+  it("empty → evict + inline re-mint → retry SAME proxy → success (Q1=B)", async () => {
     const proxyPool = new FakeProxyPool(["A", "B"]);
-    const deps = makeDeps({ proxyPool });
+    const evicted: Array<string | undefined> = [];
+    const refreshed: Array<string | undefined> = [];
+    const deps = makeDeps({
+      proxyPool,
+      scheduler: {
+        refreshOnDemand: async () => ({ bearer: "", expiresAt: null }),
+        refreshBaxiaToken: async (proxy?: string) => { refreshed.push(proxy); },
+        evictBaxiaToken: (proxy?: string) => { evicted.push(proxy); },
+      },
+    });
     const seen: string[] = [];
     let callCount = 0;
 
@@ -199,8 +208,10 @@ describe("withPoolRetry — rotation mode", () => {
     });
 
     expect(result).toBe("ok");
-    expect(seen).toEqual(["A", "B"]);
-    expect(proxyPool.rotateCalls).toBe(1);
+    expect(seen).toEqual(["A", "A"]); // re-mint retry stays on the same proxy
+    expect(evicted).toEqual(["A"]);
+    expect(refreshed).toEqual(["A"]);
+    expect(proxyPool.rotateCalls).toBe(0);
   });
 
   it("NetworkError → rotate → success", async () => {
@@ -232,13 +243,13 @@ describe("withPoolRetry — rotation mode", () => {
 
   it("budget=size (N=2): A→B exhausted → RateLimitError + cooldown", async () => {
     const proxyPool = new FakeProxyPool(["A", "B"]);
-    let refreshBaxiaCalled = 0;
+    const refreshProxies: Array<string | undefined> = [];
     const deps = makeDeps({
       proxyPool,
       config: { emptyCooldownMs: 10, emptyRetryMax: 99, emptyRetryGapMs: 0 },
       scheduler: {
         refreshOnDemand: async () => ({ bearer: "", expiresAt: null }),
-        refreshBaxiaToken: async () => { refreshBaxiaCalled++; },
+        refreshBaxiaToken: async (proxy?: string) => { refreshProxies.push(proxy); },
       },
     });
 
@@ -249,7 +260,8 @@ describe("withPoolRetry — rotation mode", () => {
     ).rejects.toThrow(RateLimitError);
 
     expect(proxyPool.rotateCalls).toBe(1); // rotated once (A→B), then all burned
-    expect(refreshBaxiaCalled).toBe(0); // NO refreshBaxiaToken in rotation mode
+    // Q1=B inline re-mint on A, then change #2 sentinel refresh of the active proxy (B)
+    expect(refreshProxies).toEqual(["A", "B"]);
   });
 
   it("AuthExpired → refresh + retry SAME proxy (no rotate)", async () => {
@@ -367,8 +379,9 @@ describe("withPoolRetryStream — rotation mode", () => {
     }
 
     const chunks = await collectChunks(withPoolRetryStream(deps, op));
-    expect(seen).toEqual(["A", "B"]);
-    expect(proxyPool.rotateCalls).toBe(1);
+    // Q1=B: first empty evicts + inline re-mints, retrying the SAME proxy
+    expect(seen).toEqual(["A", "A"]);
+    expect(proxyPool.rotateCalls).toBe(0);
     expect(chunks).toEqual([contentChunk("recovered"), finishChunk("stop")]);
   });
 
@@ -392,8 +405,13 @@ describe("withPoolRetryStream — rotation mode", () => {
 
   it("budget=size N=2: both-empty → sentinel (no legacy retry)", async () => {
     const proxyPool = new FakeProxyPool(["A", "B"]);
+    const refreshedProxies: Array<string | undefined> = [];
     const deps = rotStreamDeps(proxyPool, {
       config: { emptyCooldownMs: 10, emptyRetryMax: 99, emptyRetryGapMs: 0 },
+      scheduler: {
+        refreshOnDemand: async () => ({ bearer: "", expiresAt: null }),
+        refreshBaxiaToken: async (proxy?: string) => { refreshedProxies.push(proxy); },
+      },
     });
     let callCount = 0;
 
@@ -407,8 +425,8 @@ describe("withPoolRetryStream — rotation mode", () => {
     }
 
     const chunks = await collectChunks(withPoolRetryStream(deps, op));
-    // N=2: try A (empty), rotate to B (empty), all burned → sentinel
-    expect(callCount).toBe(2);
+    // N=2, Q1=B: A empty → re-mint retry A → empty → rotate B → empty → all burned → sentinel
+    expect(callCount).toBe(3);
     expect(proxyPool.rotateCalls).toBe(1);
     expect(chunks).toHaveLength(1);
     const sentinel = chunks[0];
@@ -418,6 +436,9 @@ describe("withPoolRetryStream — rotation mode", () => {
     } else {
       throw new Error("Expected sentinel");
     }
+    // change #2: all-burned sentinel refreshed the active proxy's token (B)
+    // after the inline re-mint on A.
+    expect(refreshedProxies).toEqual(["A", "B"]);
   });
 });
 
@@ -926,5 +947,274 @@ describe("retry.ts branch dispatch (S-M5-78)", () => {
 
     await collectChunks(withPoolRetryStream(deps, op));
     expect(calls).toContain("markSuccess");
+  });
+});
+
+// ── retry contracts (S-M3-2): scheduler hooks + optional pool slots ─────────
+
+describe("RetryScheduler burn-recovery hooks (compile surface)", () => {
+  it("a scheduler with refreshBaxiaToken(proxy?)/evictBaxiaToken/baxiaTokenAgeMs satisfies the contract", async () => {
+    const calls: string[] = [];
+    const scheduler = {
+      refreshOnDemand: async () => ({ bearer: "b", expiresAt: null }),
+      refreshBaxiaToken: async (proxy?: string) => { calls.push("refresh:" + (proxy ?? "active")); },
+      evictBaxiaToken: (proxy?: string) => { calls.push("evict:" + (proxy ?? "active")); },
+      baxiaTokenAgeMs: (proxy?: string) => (proxy ? 1234 : null),
+    };
+    // Type-level check executed at runtime through the optional hooks.
+    await scheduler.refreshBaxiaToken?.("socks5://u:p@h:1080");
+    scheduler.evictBaxiaToken?.("socks5://u:p@h:1080");
+    expect(scheduler.baxiaTokenAgeMs?.("socks5://u:p@h:1080")).toBe(1234);
+    expect(calls).toEqual(["refresh:socks5://u:p@h:1080", "evict:socks5://u:p@h:1080"]);
+  });
+});
+
+// ── burn recovery: slots + inline re-mint + walk logging (S-M3-3) ───────────
+
+/** Fake slot-aware pool mirroring ProxyPool sticky-first semantics, with recording. */
+class FakeSlotPool implements ProxyPoolLike {
+  readonly keys: string[];
+  private head = 0;
+  private busy = new Set<string>();
+  readonly acquiredKeys: string[] = [];
+  readonly releasedKeys: string[] = [];
+  rotateCalls = 0;
+  constructor(keys: string[]) { this.keys = keys; }
+  get size(): number { return this.keys.length; }
+  getActive(): string | undefined { return this.keys[this.head]; }
+  rotate(): string | undefined {
+    this.rotateCalls++;
+    this.head = (this.head + 1) % this.keys.length;
+    return this.keys[this.head];
+  }
+  async acquire(): Promise<string> {
+    for (let i = 0; i < this.keys.length; i++) {
+      const k = this.keys[(this.head + i) % this.keys.length];
+      if (!this.busy.has(k)) {
+        this.head = (this.head + i) % this.keys.length;
+        this.busy.add(k);
+        this.acquiredKeys.push(k);
+        return k;
+      }
+    }
+    // all busy — wait for the next release (test pools never hit this)
+    await new Promise<void>(() => {});
+    return this.keys[this.head];
+  }
+  release(key: string): void {
+    this.busy.delete(key);
+    this.releasedKeys.push(key);
+  }
+}
+
+describe("withPoolRetry — burn recovery (S-M3-3)", () => {
+  const PA = "socks5://u:p@hA:1080";
+  const PB = "socks5://u:p@hB:1080";
+
+  function burnDeps(pool: ProxyPoolLike, opts?: { cooldownMs?: number }) {
+    const evicted: Array<string | undefined> = [];
+    const refreshed: Array<string | undefined> = [];
+    const warns: Array<{ msg: string; ctx: any }> = [];
+    const deps = makeDeps({
+      proxyPool: pool,
+      config: { emptyCooldownMs: opts?.cooldownMs ?? 10, emptyRetryMax: 99, emptyRetryGapMs: 0 },
+      scheduler: {
+        refreshOnDemand: async () => ({ bearer: "", expiresAt: null }),
+        refreshBaxiaToken: async (proxy?: string) => { refreshed.push(proxy); },
+        evictBaxiaToken: (proxy?: string) => { evicted.push(proxy); },
+        baxiaTokenAgeMs: () => 4321,
+      },
+      log: {
+        info: () => {},
+        warn: (msg: string, ctx?: unknown) => warns.push({ msg, ctx }),
+        error: () => {},
+      },
+    });
+    return { deps, evicted, refreshed, warns };
+  }
+
+  it("slot lifecycle: acquire once per request, op sees the key, release exactly once on success", async () => {
+    const pool = new FakeSlotPool([PA, PB]);
+    const { deps } = burnDeps(pool);
+    const seen: string[] = [];
+    const result = await withPoolRetry(deps, async (_id, _b, proxy?) => { seen.push(proxy!); return "ok"; });
+    expect(result).toBe("ok");
+    expect(pool.acquiredKeys.length).toBe(1);
+    expect(seen).toEqual([pool.acquiredKeys[0]]);
+    expect(pool.releasedKeys).toEqual([pool.acquiredKeys[0]]);
+  });
+
+  it("second empty on P → rotate away (inline re-mint bounded to one per request)", async () => {
+    const pool = new FakeSlotPool([PA, PB]);
+    const { deps, evicted, refreshed } = burnDeps(pool);
+    const seen: string[] = [];
+    const result = await withPoolRetry(deps, async (_id, _b, proxy?) => {
+      seen.push(proxy!);
+      if (seen.length <= 2) throw new EmptyCompletionError("empty"); // A, re-minted A
+      return "ok-" + (proxy === PA ? "A" : "B");
+    });
+    expect(result).toBe("ok-B");
+    expect(seen).toEqual([PA, PA, PB]);
+    expect(evicted).toEqual([PA, PA]);
+    expect(refreshed).toEqual([PA]);
+    expect(pool.rotateCalls).toBe(1);
+  });
+
+  it("all burned (N=2, always empty): RateLimitError + evictions + sentinel refresh of the ACTIVE proxy", async () => {
+    const pool = new FakeSlotPool([PA, PB]);
+    const { deps, evicted, refreshed } = burnDeps(pool, { cooldownMs: 5 });
+    await expect(
+      withPoolRetry(deps, async () => { throw new EmptyCompletionError("empty"); }),
+    ).rejects.toThrow(RateLimitError);
+    expect(evicted).toEqual([PA, PA, PB]);
+    // re-mint on A, then the all-burned sentinel refreshes the last active proxy (B)
+    expect(refreshed).toEqual([PA, PB]);
+  });
+
+  it("empty-walk logging: per-attempt warn with redacted proxy, tried/size, tokenAgeMs; no creds", async () => {
+    const pool = new FakeSlotPool([PA, PB]);
+    const { deps, warns } = burnDeps(pool, { cooldownMs: 5 });
+    await expect(
+      withPoolRetry(deps, async () => { throw new EmptyCompletionError("empty"); }),
+    ).rejects.toThrow(RateLimitError);
+    const walks = warns.filter((w) => w.msg.includes("empty completion — walking"));
+    expect(walks.length).toBe(3); // A, re-minted A, B
+    for (const w of walks) {
+      expect(w.ctx.proxy).toMatch(/^h[AB]:1080$/); // redacted host:port
+      expect(w.ctx.size).toBe(2);
+      expect(w.ctx.tokenAgeMs).toBe(4321);
+    }
+    expect(JSON.stringify(warns)).not.toContain("u:p@");
+  });
+
+  it("slot release on throw (all-burned path frees the slot)", async () => {
+    const pool = new FakeSlotPool([PA, PB]);
+    const { deps } = burnDeps(pool, { cooldownMs: 5 });
+    await expect(
+      withPoolRetry(deps, async () => { throw new EmptyCompletionError("empty"); }),
+    ).rejects.toThrow(RateLimitError);
+    expect(pool.releasedKeys.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("non-empty error path all-burned also refreshes the active proxy's token (change #2)", async () => {
+    const pool = new FakeProxyPool(["A", "B"]);
+    const refreshed: Array<string | undefined> = [];
+    const deps = makeDeps({
+      proxyPool: pool,
+      config: { emptyCooldownMs: 5, emptyRetryMax: 99, emptyRetryGapMs: 0 },
+      scheduler: {
+        refreshOnDemand: async () => ({ bearer: "", expiresAt: null }),
+        refreshBaxiaToken: async (proxy?: string) => { refreshed.push(proxy); },
+      },
+    });
+    await expect(
+      withPoolRetry(deps, async () => { throw new NetworkError("timeout"); }),
+    ).rejects.toThrow(RateLimitError);
+    expect(refreshed.length).toBe(1); // after cooldown, before the 429
+  });
+});
+
+// ── stream burn recovery: slots + re-mint + walk logging (S-M3-4) ───────────
+
+describe("withPoolRetryStream — burn recovery (S-M3-4)", () => {
+  const PA = "socks5://u:p@hA:1080";
+  const PB = "socks5://u:p@hB:1080";
+
+  function burnStreamDeps(pool: ProxyPoolLike) {
+    const evicted: Array<string | undefined> = [];
+    const refreshed: Array<string | undefined> = [];
+    const order: string[] = [];
+    const warns: Array<{ msg: string; ctx: any }> = [];
+    const deps = makeDeps({
+      proxyPool: pool,
+      config: { emptyCooldownMs: 10, emptyRetryMax: 99, emptyRetryGapMs: 0 },
+      scheduler: {
+        refreshOnDemand: async () => ({ bearer: "", expiresAt: null }),
+        refreshBaxiaToken: async (proxy?: string) => { refreshed.push(proxy); order.push("refresh"); },
+        evictBaxiaToken: (proxy?: string) => { evicted.push(proxy); order.push("evict"); },
+        baxiaTokenAgeMs: () => 4321,
+      },
+      log: {
+        info: () => {},
+        warn: (msg: string, ctx?: unknown) => warns.push({ msg, ctx }),
+        error: () => {},
+      },
+    });
+    return { deps, evicted, refreshed, order, warns };
+  }
+
+  it("slot lifecycle on stream: acquire once, release once on clean end", async () => {
+    const pool = new FakeSlotPool([PA, PB]);
+    const { deps } = burnStreamDeps(pool);
+    async function* op(): AsyncIterable<OpenAiChatChunk> {
+      yield contentChunk("hi");
+      yield finishChunk("stop");
+    }
+    const chunks = await collectChunks(withPoolRetryStream(deps, op));
+    expect(chunks.length).toBe(2);
+    expect(pool.acquiredKeys.length).toBe(1);
+    expect(pool.releasedKeys).toEqual([pool.acquiredKeys[0]]);
+  });
+
+  it("second empty on P → rotate away (one inline re-mint per request)", async () => {
+    const pool = new FakeSlotPool([PA, PB]);
+    const { deps, evicted, refreshed } = burnStreamDeps(pool);
+    const seen: string[] = [];
+    async function* op(_id: number, _b: string, proxy?: string): AsyncIterable<OpenAiChatChunk> {
+      seen.push(proxy!);
+      if (seen.length <= 2) {
+        yield finishChunk("stop"); // empty — no payload
+        return;
+      }
+      yield contentChunk("recovered");
+      yield finishChunk("stop");
+    }
+    const chunks = await collectChunks(withPoolRetryStream(deps, op));
+    expect(seen).toEqual([PA, PA, PB]);
+    expect(evicted).toEqual([PA, PA]); // evict on empty only — PB served content
+    expect(refreshed).toEqual([PA]);
+    expect(pool.rotateCalls).toBe(1);
+    expect(chunks[0]).toEqual(contentChunk("recovered"));
+  });
+
+  it("all-burned error path: sentinel + refresh of the active proxy (new)", async () => {
+    const pool = new FakeSlotPool([PA, PB]);
+    const { deps, refreshed, order } = burnStreamDeps(pool);
+    async function* op(): AsyncIterable<OpenAiChatChunk> {
+      throw new NetworkError("connect fail");
+    }
+    const chunks = await collectChunks(withPoolRetryStream(deps, op));
+    expect(chunks).toHaveLength(1);
+    expect((chunks[0] as any).done).toBe(true);
+    expect((chunks[0] as any).extra?.rateLimited).toBe(true);
+    expect(refreshed.length).toBe(1); // change #2 on the error path too
+    expect(order[order.length - 1]).toBe("refresh"); // refresh completed before the sentinel
+  });
+
+  it("empty-walk logging: per-attempt warn with redacted proxy; no creds", async () => {
+    const pool = new FakeSlotPool([PA, PB]);
+    const { deps, warns } = burnStreamDeps(pool);
+    async function* op(): AsyncIterable<OpenAiChatChunk> {
+      yield finishChunk("stop"); // always empty
+    }
+    await collectChunks(withPoolRetryStream(deps, op));
+    const walks = warns.filter((w) => w.msg.includes("empty completion — walking"));
+    expect(walks.length).toBe(3); // A, re-minted A, B
+    expect(JSON.stringify(warns)).not.toContain("u:p@");
+  });
+
+  it("consumer break post-content: slot released (generator finally)", async () => {
+    const pool = new FakeSlotPool([PA, PB]);
+    const { deps } = burnStreamDeps(pool);
+    let stalled: (() => void) | undefined;
+    async function* op(): AsyncIterable<OpenAiChatChunk> {
+      yield contentChunk("partial");
+      await new Promise<void>((r) => { stalled = r; }); // never completes
+      yield contentChunk("never");
+    }
+    const iter = withPoolRetryStream(deps, op);
+    for await (const _ of iter) break; // abandon after first chunk
+    expect(pool.releasedKeys).toEqual([pool.acquiredKeys[0]]);
+    stalled?.();
   });
 });

--- a/packages/qwen-proxy/tests/server/admin-routes.test.ts
+++ b/packages/qwen-proxy/tests/server/admin-routes.test.ts
@@ -182,6 +182,7 @@ describe("adminRoutes integration via createApp", () => {
       nextRefreshInMs: 1_380_000,
       lastSpawnDurationMs: 3_200,
       consecutiveFailures: 0,
+      requestsServed: 0,
     };
     deps.baxiaStatus = () => baxia;
     const app = createApp(deps);
@@ -211,6 +212,7 @@ describe("adminRoutes integration via createApp", () => {
       nextRefreshInMs: null,
       lastSpawnDurationMs: null,
       consecutiveFailures: 0,
+      requestsServed: 0,
     };
     deps.baxiaStatus = () => baxia;
     const app = createApp(deps);
@@ -231,6 +233,7 @@ describe("adminRoutes integration via createApp", () => {
       nextRefreshInMs: 1_500_000,
       lastSpawnDurationMs: 3_000,
       consecutiveFailures: 0,
+      requestsServed: 0,
     });
     const app = createApp(deps);
     const res = await app.request("/admin");

--- a/packages/qwen-proxy/tests/server/admin-routes.test.ts
+++ b/packages/qwen-proxy/tests/server/admin-routes.test.ts
@@ -114,6 +114,8 @@ function makeStubDeps(adminKey?: string): AppDeps {
       emptyRetryGapMs: 1_000,
       minRequestGapMs: 0,
       maxConcurrency: 1,
+      firstPayloadTimeoutMs: 30_000,
+      streamIdleTimeoutMs: 30_000,
       apiKeyEnv: [],
       modelAliasesRaw: "",
       logLevel: "info",

--- a/packages/qwen-proxy/tests/start.test.ts
+++ b/packages/qwen-proxy/tests/start.test.ts
@@ -24,6 +24,8 @@ function makeStubDeps(): AppDeps {
       emptyRetryGapMs: 1_000,
       minRequestGapMs: 0,
       maxConcurrency: 1,
+      firstPayloadTimeoutMs: 30_000,
+      streamIdleTimeoutMs: 30_000,
       apiKeyEnv: [],
       modelAliasesRaw: "",
       logLevel: "info",

--- a/packages/qwen-proxy/tests/upstream/baxia-token.test.ts
+++ b/packages/qwen-proxy/tests/upstream/baxia-token.test.ts
@@ -891,3 +891,232 @@ describe("bridge integration", () => {
     }
   });
 });
+
+// ── requests-per-token counter (S-M1-2) ─────────────────────────────────────
+
+describe("requests-per-token counter", () => {
+  function makeCounterSetup() {
+    let evalCount = 0;
+    const replyMap = new Map<string, (id: number, params: any) => any>();
+    replyMap.set("Page.enable", () => ({}));
+    replyMap.set("Runtime.enable", () => ({}));
+    replyMap.set("Page.navigate", () => ({ frameId: "f1" }));
+    replyMap.set("Runtime.evaluate", (_id, params) => {
+      if (params?.expression?.includes("__baxia__")) {
+        evalCount++;
+        const uid = "T2gA" + String.fromCharCode(65 + evalCount - 1).repeat(24);
+        return { result: { type: "object", value: { ready: true, fy: "FY" + evalCount, uid, cookie: "ck" + evalCount } } };
+      }
+      return { result: { type: "undefined" } };
+    });
+    const fetcherFn = vi.fn(async (url: string) => {
+      if (url.includes("/json/list")) {
+        return { ok: true, json: async () => [{ type: "page", webSocketDebuggerUrl: "ws://127.0.0.1:9222/devtools/page/abc" }] };
+      }
+      return { ok: false, json: async () => ({}) };
+    });
+    const config = makeConfig({
+      spawn: vi.fn(() => ({ pid: 1, kill: vi.fn() })) as any,
+      WebSocketCtor: function (url: string) { return new FakeWebSocket(url, replyMap) as any; } as any,
+      fetcher: fetcherFn as any,
+      sleep: () => Promise.resolve(),
+      now: vi.fn(() => 1000),
+    });
+    return { config, spawnCount: () => (config.spawn as ReturnType<typeof vi.fn>).mock.calls.length };
+  }
+
+  it("recordRequestServed increments per-proxy entry; proxyStatuses exposes it", async () => {
+    const { BaxiaTokenManager } = await import("../../src/upstream/baxia-token");
+    const { config } = makeCounterSetup();
+    const mgr = new BaxiaTokenManager(config);
+    const P = "socks5://u:p@counterA:1080";
+
+    await mgr.ensureToken({ proxy: P });
+    mgr.recordRequestServed(P);
+    mgr.recordRequestServed(P);
+    mgr.recordRequestServed(P);
+    expect(mgr.proxyStatuses()[P].requestsServed).toBe(3);
+  });
+
+  it("forceRefresh re-mint resets the counter to 0", async () => {
+    const { BaxiaTokenManager } = await import("../../src/upstream/baxia-token");
+    const { config } = makeCounterSetup();
+    const mgr = new BaxiaTokenManager(config);
+    const P = "socks5://u:p@counterB:1080";
+
+    await mgr.ensureToken({ proxy: P });
+    mgr.recordRequestServed(P);
+    mgr.recordRequestServed(P);
+    await mgr.ensureToken({ forceRefresh: true, proxy: P });
+    expect(mgr.proxyStatuses()[P].requestsServed).toBe(0);
+  });
+
+  it("recordRequestServed on unknown key is a no-op (no throw, no entry created)", async () => {
+    const { BaxiaTokenManager } = await import("../../src/upstream/baxia-token");
+    const { config } = makeCounterSetup();
+    const mgr = new BaxiaTokenManager(config);
+    expect(() => mgr.recordRequestServed("socks5://u:p@never-minted:1080")).not.toThrow();
+    expect(mgr.proxyStatuses()["socks5://u:p@never-minted:1080"]).toBeUndefined();
+  });
+
+  it("status() reports requestsServed for the last-used proxy", async () => {
+    const { BaxiaTokenManager } = await import("../../src/upstream/baxia-token");
+    const { config } = makeCounterSetup();
+    const mgr = new BaxiaTokenManager(config);
+    const P = "socks5://u:p@counterC:1080";
+    await mgr.ensureToken({ proxy: P });
+    mgr.recordRequestServed(P);
+    expect(mgr.status().requestsServed).toBe(1);
+  });
+});
+
+// ── evictToken (S-M1-3) ─────────────────────────────────────────────────────
+
+describe("evictToken", () => {
+  it("evicted token re-mints on next ensureToken even within TTL", async () => {
+    const { BaxiaTokenManager } = await import("../../src/upstream/baxia-token");
+    let evalCount = 0;
+    const replyMap = new Map<string, (id: number, params: any) => any>();
+    replyMap.set("Page.enable", () => ({}));
+    replyMap.set("Runtime.enable", () => ({}));
+    replyMap.set("Page.navigate", () => ({ frameId: "f1" }));
+    replyMap.set("Runtime.evaluate", (_id, params) => {
+      if (params?.expression?.includes("__baxia__")) {
+        evalCount++;
+        const uid = "T2gA" + String.fromCharCode(65 + evalCount - 1).repeat(24);
+        return { result: { type: "object", value: { ready: true, fy: "FY" + evalCount, uid, cookie: "ck" + evalCount } } };
+      }
+      return { result: { type: "undefined" } };
+    });
+    const spawnFn = vi.fn(() => ({ pid: 1, kill: vi.fn() }));
+    const config = makeConfig({
+      spawn: spawnFn as any,
+      WebSocketCtor: function (url: string) { return new FakeWebSocket(url, replyMap) as any; } as any,
+      fetcher: vi.fn(async (url: string) => {
+        if (url.includes("/json/list")) {
+          return { ok: true, json: async () => [{ type: "page", webSocketDebuggerUrl: "ws://127.0.0.1:9222/devtools/page/abc" }] };
+        }
+        return { ok: false, json: async () => ({}) };
+      }) as any,
+      sleep: () => Promise.resolve(),
+      now: vi.fn(() => 1000),
+    });
+    const mgr = new BaxiaTokenManager(config);
+    const P = "socks5://u:p@evictA:1080";
+
+    const t1 = await mgr.ensureToken({ proxy: P });
+    expect(spawnFn).toHaveBeenCalledTimes(1);
+
+    mgr.evictToken(P);
+
+    // Within TTL — but the entry was evicted, so this MUST re-mint.
+    const t2 = await mgr.ensureToken({ proxy: P });
+    expect(spawnFn).toHaveBeenCalledTimes(2);
+    expect(t2.bxUmidToken).not.toBe(t1.bxUmidToken);
+
+    // New generation's counter starts at 0.
+    expect(mgr.proxyStatuses()[P].requestsServed).toBe(0);
+  });
+
+  it("evictToken on unknown key is a no-op (no throw, no log)", async () => {
+    const { BaxiaTokenManager } = await import("../../src/upstream/baxia-token");
+    const warn = vi.fn();
+    const config = makeConfig({ log: { info: vi.fn(), warn, error: vi.fn() } });
+    const mgr = new BaxiaTokenManager(config);
+    expect(() => mgr.evictToken("socks5://u:p@unknown:1080")).not.toThrow();
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("evictToken logs requestsServed + redacted proxy + ageMs", async () => {
+    const { BaxiaTokenManager } = await import("../../src/upstream/baxia-token");
+    const records: Array<{ msg: string; ctx: any }> = [];
+    const log = {
+      info: vi.fn(),
+      warn: (msg: string, ctx?: unknown) => records.push({ msg, ctx }),
+      error: vi.fn(),
+    };
+    let currentTime = 1000;
+    let evalCount = 0;
+    const replyMap = new Map<string, (id: number, params: any) => any>();
+    replyMap.set("Page.enable", () => ({}));
+    replyMap.set("Runtime.enable", () => ({}));
+    replyMap.set("Page.navigate", () => ({ frameId: "f1" }));
+    replyMap.set("Runtime.evaluate", (_id, params) => {
+      if (params?.expression?.includes("__baxia__")) {
+        evalCount++;
+        const uid = "T2gA" + String.fromCharCode(65 + evalCount - 1).repeat(24);
+        return { result: { type: "object", value: { ready: true, fy: "FY" + evalCount, uid, cookie: "ck" + evalCount } } };
+      }
+      return { result: { type: "undefined" } };
+    });
+    const config = makeConfig({
+      spawn: vi.fn(() => ({ pid: 1, kill: vi.fn() })) as any,
+      WebSocketCtor: function (url: string) { return new FakeWebSocket(url, replyMap) as any; } as any,
+      fetcher: vi.fn(async (url: string) => {
+        if (url.includes("/json/list")) {
+          return { ok: true, json: async () => [{ type: "page", webSocketDebuggerUrl: "ws://127.0.0.1:9222/devtools/page/abc" }] };
+        }
+        return { ok: false, json: async () => ({}) };
+      }) as any,
+      sleep: () => Promise.resolve(),
+      now: () => currentTime,
+      log,
+    });
+    const mgr = new BaxiaTokenManager(config);
+    const P = "socks5://secretuser:secretpass@evictB:1080";
+
+    await mgr.ensureToken({ proxy: P });
+    mgr.recordRequestServed(P);
+    mgr.recordRequestServed(P);
+    mgr.recordRequestServed(P);
+    currentTime += 45_000;
+    mgr.evictToken(P);
+
+    const burn = records.find((r) => r.msg.includes("token burned"));
+    expect(burn).toBeDefined();
+    expect(burn!.ctx.proxy).toBe("evictB:1080");            // redacted — no creds
+    expect(burn!.ctx.requestsServed).toBe(3);
+    expect(burn!.ctx.ageMs).toBe(45_000);
+    expect(JSON.stringify(records)).not.toContain("secretuser");
+    expect(JSON.stringify(records)).not.toContain("secretpass");
+  });
+});
+
+// ── log redaction (S-M1-4) ──────────────────────────────────────────────────
+
+describe("baxia log redaction", () => {
+  it("no log record contains proxy credentials; proxy fields are host:port", async () => {
+    const { BaxiaTokenManager } = await import("../../src/upstream/baxia-token");
+    const records: Array<{ msg: string; ctx: any }> = [];
+    const log = {
+      info: (msg: string, ctx?: unknown) => records.push({ msg, ctx }),
+      warn: (msg: string, ctx?: unknown) => records.push({ msg, ctx }),
+      error: (msg: string, ctx?: unknown) => records.push({ msg, ctx }),
+    };
+    const replyMap = makeDefaultReplyMap();
+    const config = makeConfig({
+      spawn: vi.fn(() => ({ pid: 1, kill: vi.fn() })) as any,
+      WebSocketCtor: function (url: string) { return new FakeWebSocket(url, replyMap) as any; } as any,
+      fetcher: vi.fn(async (url: string) => {
+        if (url.includes("/json/list")) {
+          return { ok: true, json: async () => [{ type: "page", webSocketDebuggerUrl: "ws://127.0.0.1:9222/devtools/page/abc" }] };
+        }
+        return { ok: false, json: async () => ({}) };
+      }) as any,
+      sleep: () => Promise.resolve(),
+      now: vi.fn(() => 1000),
+      log,
+    });
+    const mgr = new BaxiaTokenManager(config);
+    const CREDS = "socks5://leakyuser:leakypass@redact-me:1080";
+
+    await mgr.ensureToken({ proxy: CREDS });
+
+    const serialized = JSON.stringify(records);
+    expect(serialized).not.toContain("leakyuser");
+    expect(serialized).not.toContain("leakypass");
+    const spawnLog = records.find((r) => r.msg.includes("chromium spawn"));
+    expect(spawnLog).toBeDefined();
+    expect(spawnLog!.ctx.proxy).toBe("redact-me:1080");
+  });
+});

--- a/packages/qwen-proxy/tests/upstream/guest-client.test.ts
+++ b/packages/qwen-proxy/tests/upstream/guest-client.test.ts
@@ -23,6 +23,7 @@ function makeBaxia(overrides?: Partial<BaxiaTokenManager>): BaxiaTokenManager {
     startRefreshLoop: vi.fn(),
     stop: vi.fn(),
     status: vi.fn(),
+    recordRequestServed: vi.fn(),
     ...overrides,
   } as unknown as BaxiaTokenManager;
 }
@@ -151,6 +152,7 @@ describe("createChatSession", () => {
       startRefreshLoop: vi.fn(),
       stop: vi.fn(),
       status: vi.fn(),
+    recordRequestServed: vi.fn(),
     } as unknown as BaxiaTokenManager;
 
     const fetcher = vi.fn()
@@ -1091,5 +1093,131 @@ describe("S-M1-6: TTFB timeout", () => {
     }
     expect(caught).toBeInstanceOf(NetworkError);
     expect((caught as NetworkError).message).toContain("TTFB");
+  });
+});
+
+// ── stall guard wiring + counter + redaction (S-M2-3) ───────────────────────
+
+describe("stall guard wiring (S-M2-3)", () => {
+  const CREDS_PROXY = "socks5://u9:p9@h9:1080";
+
+  function sessionOk() {
+    return { ok: true, json: async () => ({ data: { id: "sid-stall" } }) };
+  }
+  function silentSseResponse(): Response {
+    const body = new ReadableStream<Uint8Array>({ start() {} }); // headers, then silence
+    return { ok: true, body } as unknown as Response;
+  }
+  function stallAfterContentResponse(): Response {
+    const encoder = new TextEncoder();
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode(`data: ${JSON.stringify({ choices: [{ delta: { content: "partial" } }] })}\n\n`));
+        // then silence forever
+      },
+    });
+    return { ok: true, body } as unknown as Response;
+  }
+
+  it("stream: silent body + firstPayloadTimeoutMs=50 → EmptyCompletionError, semaphore released", async () => {
+    const fetcher = vi.fn().mockResolvedValueOnce(sessionOk()).mockResolvedValueOnce(silentSseResponse());
+    const sem = { held: 0, async acquire() { this.held += 1; }, release() { this.held -= 1; } };
+    const client = new GuestUpstreamClient({
+      baxia: makeBaxia(),
+      chatUrl: "https://chat.qwen.ai",
+      fetcher: fetcher as unknown as typeof fetch,
+      log: noopLog,
+      concurrency: sem,
+      stallGuard: { firstPayloadTimeoutMs: 50, idleTimeoutMs: 0 },
+    });
+    const stream = client.chatCompletions("b", { model: "m", messages: [{ role: "user", content: "x" }], stream: true });
+    await expect(async () => {
+      for await (const _ of stream as AsyncIterable<any>) { /* drain */ }
+    }).rejects.toThrow(EmptyCompletionError);
+    expect(sem.held).toBe(0);
+  });
+
+  it("non-stream: silent body + firstPayloadTimeoutMs=50 → EmptyCompletionError, semaphore released", async () => {
+    const fetcher = vi.fn().mockResolvedValueOnce(sessionOk()).mockResolvedValueOnce(silentSseResponse());
+    const sem = { held: 0, async acquire() { this.held += 1; }, release() { this.held -= 1; } };
+    const client = new GuestUpstreamClient({
+      baxia: makeBaxia(),
+      chatUrl: "https://chat.qwen.ai",
+      fetcher: fetcher as unknown as typeof fetch,
+      log: noopLog,
+      concurrency: sem,
+      stallGuard: { firstPayloadTimeoutMs: 50, idleTimeoutMs: 0 },
+    });
+    await expect(
+      client.chatCompletions("b", { model: "m", messages: [{ role: "user", content: "x" }], stream: false }),
+    ).rejects.toThrow(EmptyCompletionError);
+    expect(sem.held).toBe(0);
+  });
+
+  it("stream: content then silence + idleTimeoutMs=40 → yields partial then ends gracefully", async () => {
+    const fetcher = vi.fn().mockResolvedValueOnce(sessionOk()).mockResolvedValueOnce(stallAfterContentResponse());
+    const client = new GuestUpstreamClient({
+      baxia: makeBaxia(),
+      chatUrl: "https://chat.qwen.ai",
+      fetcher: fetcher as unknown as typeof fetch,
+      log: noopLog,
+      stallGuard: { firstPayloadTimeoutMs: 0, idleTimeoutMs: 40 },
+    });
+    const chunks: any[] = [];
+    for await (const c of client.chatCompletions("b", { model: "m", messages: [{ role: "user", content: "x" }], stream: true }) as AsyncIterable<any>) {
+      chunks.push(c);
+    }
+    expect(chunks.length).toBe(1);
+    expect(chunks[0].choices[0].delta.content).toBe("partial");
+  });
+
+  it("non-stream: content then silence + idleTimeoutMs=40 → returns partial completion", async () => {
+    const fetcher = vi.fn().mockResolvedValueOnce(sessionOk()).mockResolvedValueOnce(stallAfterContentResponse());
+    const client = new GuestUpstreamClient({
+      baxia: makeBaxia(),
+      chatUrl: "https://chat.qwen.ai",
+      fetcher: fetcher as unknown as typeof fetch,
+      log: noopLog,
+      stallGuard: { firstPayloadTimeoutMs: 0, idleTimeoutMs: 40 },
+    });
+    const completion = (await client.chatCompletions("b", { model: "m", messages: [{ role: "user", content: "x" }], stream: false })) as any;
+    expect(completion.choices[0].message.content).toBe("partial");
+  });
+
+  it("createChatSession OK records the request against the proxy token", async () => {
+    const fetcher = vi.fn().mockResolvedValueOnce(sessionOk()).mockResolvedValueOnce(silentSseResponse());
+    const baxia = makeBaxia();
+    const client = new GuestUpstreamClient({
+      baxia, chatUrl: "https://chat.qwen.ai", fetcher: fetcher as unknown as typeof fetch, log: noopLog,
+      stallGuard: { firstPayloadTimeoutMs: 30, idleTimeoutMs: 0 },
+    });
+    // Drive one completion (session creation happens first).
+    const stream = client.chatCompletions("b", { model: "m", messages: [{ role: "user", content: "x" }], stream: true }, CREDS_PROXY);
+    await expect(async () => { for await (const _ of stream as AsyncIterable<any>) {} }).rejects.toThrow();
+    expect(baxia.recordRequestServed).toHaveBeenCalledWith(CREDS_PROXY);
+  });
+
+  it("logs contain no proxy credentials; proxy fields are host:port", async () => {
+    const records: Array<{ msg: string; ctx: any }> = [];
+    const log = {
+      info: (msg: string, ctx?: unknown) => records.push({ msg, ctx }),
+      warn: (msg: string, ctx?: unknown) => records.push({ msg, ctx }),
+      error: (msg: string, ctx?: unknown) => records.push({ msg, ctx }),
+    };
+    const fetcher = vi.fn()
+      .mockResolvedValueOnce(sessionOk())
+      .mockResolvedValueOnce(silentSseResponse());
+    const client = new GuestUpstreamClient({
+      baxia: makeBaxia(), chatUrl: "https://chat.qwen.ai", fetcher: fetcher as unknown as typeof fetch, log,
+      stallGuard: { firstPayloadTimeoutMs: 30, idleTimeoutMs: 0 },
+    });
+    const stream = client.chatCompletions("b", { model: "m", messages: [{ role: "user", content: "x" }], stream: true }, CREDS_PROXY);
+    await expect(async () => { for await (const _ of stream as AsyncIterable<any>) {} }).rejects.toThrow();
+    const serialized = JSON.stringify(records);
+    expect(serialized).not.toContain("u9:");
+    expect(serialized).not.toContain("p9@");
+    const okLog = records.find((r) => r.msg.includes("createChatSession OK"));
+    expect(okLog).toBeDefined();
+    expect(okLog!.ctx.proxy).toBe("h9:1080");
   });
 });

--- a/packages/qwen-proxy/tests/upstream/proxy-bridge.test.ts
+++ b/packages/qwen-proxy/tests/upstream/proxy-bridge.test.ts
@@ -475,3 +475,30 @@ describe("ProxyBridge socket error resilience (ECONNRESET regression)", () => {
     }
   });
 });
+
+// ── redactProxyKey (S-M1-1) ─────────────────────────────────────────────────
+
+describe("redactProxyKey", () => {
+  it("strips scheme + creds, keeps host:port (percent-encoded creds)", async () => {
+    const { redactProxyKey } = await import("../../src/upstream/proxy-bridge");
+    expect(redactProxyKey("socks5://user%40x:p%40ss@socks-nl5.nordvpn.com:1080"))
+      .toBe("socks-nl5.nordvpn.com:1080");
+  });
+
+  it("handles socks5h scheme and default port", async () => {
+    const { redactProxyKey } = await import("../../src/upstream/proxy-bridge");
+    expect(redactProxyKey("socks5h://u:p@h.example")).toBe("h.example:1080");
+    expect(redactProxyKey("socks5h://u:p@h.example:1080")).toBe("h.example:1080");
+  });
+
+  it("undefined/empty → (direct)", async () => {
+    const { redactProxyKey } = await import("../../src/upstream/proxy-bridge");
+    expect(redactProxyKey(undefined)).toBe("(direct)");
+    expect(redactProxyKey("")).toBe("(direct)");
+  });
+
+  it("garbage input → (unparsed), never throws", async () => {
+    const { redactProxyKey } = await import("../../src/upstream/proxy-bridge");
+    expect(redactProxyKey("not a url")).toBe("(unparsed)");
+  });
+});

--- a/packages/qwen-proxy/tests/upstream/stall-guard.test.ts
+++ b/packages/qwen-proxy/tests/upstream/stall-guard.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from "vitest";
+import { EmptyCompletionError } from "../../src/upstream/errors";
+import type { OpenAiChatChunk } from "../../src/upstream/types";
+
+function contentChunk(content: string): OpenAiChatChunk {
+  return { choices: [{ delta: { content } }] };
+}
+
+function usageOnlyChunk(): OpenAiChatChunk {
+  return { choices: [{ delta: {} }], usage: { prompt_tokens: 1, completion_tokens: 0, total_tokens: 1 } };
+}
+
+/** A chunk source that never yields (silent stream). */
+function silentSource(): AsyncGenerator<OpenAiChatChunk> {
+  return (async function* () {
+    await new Promise<void>(() => {}); // never resolves
+  })();
+}
+
+/** A chunk source that yields once, then stalls forever. */
+function stallAfterFirst(first: OpenAiChatChunk): AsyncGenerator<OpenAiChatChunk> {
+  return (async function* () {
+    yield first;
+    await new Promise<void>(() => {}); // never resolves
+  })();
+}
+
+function trackingBody(): { body: ReadableStream<Uint8Array>; cancelled: () => number } {
+  let cancelled = 0;
+  const body = {
+    cancel: async () => {
+      cancelled += 1;
+    },
+  } as unknown as ReadableStream<Uint8Array>;
+  return { body, cancelled: () => cancelled };
+}
+
+async function collect<T>(iter: AsyncIterable<T>): Promise<T[]> {
+  const out: T[] = [];
+  for await (const v of iter) out.push(v);
+  return out;
+}
+
+describe("withStallGuard", () => {
+  it("silent stream: first-payload timeout throws EmptyCompletionError and cancels the body", async () => {
+    const { withStallGuard } = await import("../../src/upstream/stall-guard");
+    const { body, cancelled } = trackingBody();
+    await expect(
+      collect(withStallGuard(silentSource(), body, { firstPayloadTimeoutMs: 50, idleTimeoutMs: 0 })),
+    ).rejects.toBeInstanceOf(EmptyCompletionError);
+    expect(cancelled()).toBeGreaterThanOrEqual(1);
+  });
+
+  it("payload then silence: idle timeout ends gracefully after partial content, cancels the body", async () => {
+    const { withStallGuard } = await import("../../src/upstream/stall-guard");
+    const { body, cancelled } = trackingBody();
+    const chunks = await collect(
+      withStallGuard(stallAfterFirst(contentChunk("hi")), body, { firstPayloadTimeoutMs: 0, idleTimeoutMs: 50 }),
+    );
+    expect(chunks.map((c) => c.choices?.[0]?.delta?.content)).toEqual(["hi"]);
+    expect(cancelled()).toBeGreaterThanOrEqual(1);
+  });
+
+  it("continuous chunks: no premature idle end while data flows", async () => {
+    const { withStallGuard } = await import("../../src/upstream/stall-guard");
+    const { body } = trackingBody();
+    const source = (async function* () {
+      for (let i = 0; i < 5; i++) {
+        yield contentChunk("c" + i);
+        await new Promise((r) => setTimeout(r, 20));
+      }
+    })();
+    const chunks = await collect(withStallGuard(source, body, { firstPayloadTimeoutMs: 500, idleTimeoutMs: 100 }));
+    expect(chunks.length).toBe(5);
+  });
+
+  it("usage-only chunk does NOT disarm the first-payload timer", async () => {
+    const { withStallGuard } = await import("../../src/upstream/stall-guard");
+    const { body } = trackingBody();
+    await expect(
+      collect(withStallGuard(stallAfterFirst(usageOnlyChunk()), body, { firstPayloadTimeoutMs: 50, idleTimeoutMs: 0 })),
+    ).rejects.toBeInstanceOf(EmptyCompletionError);
+  });
+
+  it("both timeouts 0: pass-through, no timers", async () => {
+    const { withStallGuard } = await import("../../src/upstream/stall-guard");
+    const { body } = trackingBody();
+    const source = (async function* () {
+      yield contentChunk("a");
+      yield contentChunk("b");
+    })();
+    const chunks = await collect(withStallGuard(source, body, {}));
+    expect(chunks.length).toBe(2);
+  });
+
+  it("consumer break: body cancelled on abandonment", async () => {
+    const { withStallGuard } = await import("../../src/upstream/stall-guard");
+    const { body, cancelled } = trackingBody();
+    const source = (async function* () {
+      yield contentChunk("a");
+      await new Promise<void>(() => {});
+    })();
+    const guard = withStallGuard(source, body, { firstPayloadTimeoutMs: 10_000, idleTimeoutMs: 10_000 });
+    for await (const _ of guard) break; // abandon after first chunk
+    await new Promise((r) => setTimeout(r, 20));
+    expect(cancelled()).toBeGreaterThanOrEqual(1);
+  });
+});


### PR DESCRIPTION
## Why (live-debugged on mini, 2026-08-14)

The unit Baxia flags is the **guest token** (~10-15 sequential requests each), not the proxy/IP. Four defects turned one burned token into a full-pool outage requiring restart:
1. Burned tokens never evicted from the per-proxy cache (25-min TTL) — a full rotation walk leaves every proxy holding a dead token.
2. The rotation-mode all-burned sentinel skips token refresh (the 0.3.1 fix exists only in the non-rotation path).
3. No post-headers stream timeout — soft-flagged tokens stall SSE mid-flight and hang both concurrency slots forever (observed: agents worked, orchestrator then got instant empties with zero log output).
4. Sticky active proxy + global semaphore concentrates concurrent streams on one token.

## What changed (user-resolved clarify decisions honored)

- **Evict + inline re-mint (Q1=B):** empty on proxy P force-refreshes P's token and retries on P once (bounded per request); P's token marked burned so later use re-mints.
- **Slot-based spread (Q2=C):** per-proxy serialization slots; assignment takes the first free proxy bounded by SF_QWEN_MAX_CONCURRENCY — spread under concurrency, sticky when sequential, no config special-cases.
- **Sentinel refresh (Q3=A):** all-burned sentinel refreshes the active proxy's token; others self-heal via eviction.
- **Stall guards, stream + non-stream (Q4):** shared first-payload timeout `SF_QWEN_FIRST_PAYLOAD_TIMEOUT_MS` (30s default; abort → EmptyCompletionError → rotation trigger) and idle timeout `SF_QWEN_STREAM_IDLE_TIMEOUT_MS` (30s default; graceful partial finish, no rateLimited flag, no eviction, counts toward the per-token counter). Both release the semaphore slot.
- **Prewarm (Q5):** rotation mode pre-mints the active proxy's token at boot under the existing `SF_QWEN_BAXIA_PRE_WARM` (no new knob).
- **Hygiene:** `redactProxyKey()` on every proxy log site (creds never logged); empty-rotation walk now logs per attempt; requests-per-token counter logged on burn.

## Validation

- 557/557 tests (509 baseline + 48 new), typecheck clean, audit gate APPROVED (0 P0-P2; 2 P3 notes documented).
- New knobs documented in all 4 env tables.
- Live validation on mini after merge/release per the acceptance brief: two consecutive 12/12 bursts with no restart; concurrent 2-stream spread; stalled stream aborts within timeout; `logs | grep -c <proxyUser>:` == 0.