### PR TITLE
fix(qwen-proxy): bound mint-failure storms — typed TokenMintError, chrome-error fast-fail, 2-strike budget

### DIFF
--- a/docs-site/packages/qwen-proxy-docker.md
+++ b/docs-site/packages/qwen-proxy-docker.md
@@ -158,6 +158,7 @@ services:
       # - SF_QWEN_ADMIN_KEY=${SF_QWEN_ADMIN_KEY}
       # Optional — Baxia cache TTL (default 25 min):
       # - SF_QWEN_BAXIA_CACHE_TTL_MS=1500000
+      # - SF_QWEN_BAXIA_READINESS_TIMEOUT_MS=30000
       # Optional — eagerly warm the first Baxia token at startup (default true):
       # - SF_QWEN_BAXIA_PRE_WARM=true
     restart: unless-stopped
@@ -197,6 +198,7 @@ All configuration is via environment variables (prefix `SF_QWEN_`). Set them in 
 | `SF_QWEN_LOG_LEVEL` | `info` | Log level |
 | `SF_QWEN_CHROME_PATH` | *(unset)* | Path to Chrome/Chromium; unset → autodetect (`/usr/bin/chromium` in Docker) |
 | `SF_QWEN_BAXIA_CACHE_TTL_MS` | `1500000` (25min) | Baxia token cache TTL |
+| `SF_QWEN_BAXIA_READINESS_TIMEOUT_MS` | `30000` (30s) | Max wait for Baxia SDK readiness per token mint (`chrome-error://` pages abort instantly); clamped ≥5000 |
 | `SF_QWEN_BAXIA_VERSION` | `2.5.37` | Baxia `bx-v` version |
 | `SF_QWEN_BAXIA_PRE_WARM` | `true` | Eagerly fetch the first token at startup (exit 1 on failure) |
 | `SF_QWEN_BAXIA_FALLBACK` | `false` | Return last-known token on fetch failure |

--- a/docs-site/packages/qwen-proxy.md
+++ b/docs-site/packages/qwen-proxy.md
@@ -115,6 +115,7 @@ All configuration is via environment variables (prefix `SF_QWEN_`).
 |----------|---------|-------------|
 | `SF_QWEN_CHROME_PATH` | *(unset)* | Path to Chrome/Chromium; unset → autodetect (`/usr/bin/chromium` in Docker) |
 | `SF_QWEN_BAXIA_CACHE_TTL_MS` | `1500000` (25min) | Baxia token cache TTL |
+| `SF_QWEN_BAXIA_READINESS_TIMEOUT_MS` | `30000` (30s) | Max wait for Baxia SDK readiness per token mint (`chrome-error://` pages abort instantly); clamped ≥5000 |
 | `SF_QWEN_BAXIA_VERSION` | `2.5.37` | Baxia `bx-v` version |
 | `SF_QWEN_BAXIA_PRE_WARM` | `true` | Eagerly fetch the first token at startup (exit 1 on failure) |
 | `SF_QWEN_BAXIA_FALLBACK` | `false` | Return last-known token on fetch failure |

--- a/packages/qwen-proxy/README.md
+++ b/packages/qwen-proxy/README.md
@@ -73,6 +73,7 @@ All configuration is via environment variables (prefix `SF_QWEN_`).
 | `SF_QWEN_LOG_LEVEL` | `info` | Log level |
 | `SF_QWEN_CHROME_PATH` | *(unset)* | Path to Chrome/Chromium; unset → autodetect (`/usr/bin/chromium` in Docker) |
 | `SF_QWEN_BAXIA_CACHE_TTL_MS` | `1500000` (25min) | Baxia token cache TTL |
+| `SF_QWEN_BAXIA_READINESS_TIMEOUT_MS` | `30000` (30s) | Max wait for Baxia SDK readiness per token mint (`chrome-error://` pages abort instantly); clamped ≥5000 |
 | `SF_QWEN_BAXIA_VERSION` | `2.5.37` | Baxia `bx-v` version |
 | `SF_QWEN_BAXIA_PRE_WARM` | `true` | Eagerly fetch the first token at startup (exit 1 on failure) |
 | `SF_QWEN_BAXIA_FALLBACK` | `false` | Return last-known token on fetch failure |

--- a/packages/qwen-proxy/bin/qwen-proxy.ts
+++ b/packages/qwen-proxy/bin/qwen-proxy.ts
@@ -36,6 +36,7 @@ async function main() {
       chatUrl: CHAT_URL,
       chromePath: config.baxia.chromePath,
       cacheTtlMs: config.baxia.cacheTtlMs,
+      readinessTimeoutMs: config.baxia.readinessTimeoutMs,
       baxiaVersion: config.baxia.baxiaVersion,
       fallback: config.baxia.fallback,
       userAgent:

--- a/packages/qwen-proxy/docker/README.md
+++ b/packages/qwen-proxy/docker/README.md
@@ -144,6 +144,7 @@ services:
       - SF_QWEN_CHROME_PATH=/usr/bin/chromium
       # - SF_QWEN_ADMIN_KEY=${SF_QWEN_ADMIN_KEY}
       # - SF_QWEN_BAXIA_CACHE_TTL_MS=1500000
+      # - SF_QWEN_BAXIA_READINESS_TIMEOUT_MS=30000
       # - SF_QWEN_BAXIA_PRE_WARM=true
       # - SF_QWEN_FIRST_PAYLOAD_TIMEOUT_MS=30000
       # - SF_QWEN_STREAM_IDLE_TIMEOUT_MS=30000
@@ -182,6 +183,7 @@ All configuration is via environment variables (prefix `SF_QWEN_`), set automati
 | `SF_QWEN_LOG_LEVEL` | `info` | Log level |
 | `SF_QWEN_CHROME_PATH` | *(unset)* | Path to Chrome/Chromium; unset → autodetect (`/usr/bin/chromium` in Docker) |
 | `SF_QWEN_BAXIA_CACHE_TTL_MS` | `1500000` (25min) | Baxia token cache TTL |
+| `SF_QWEN_BAXIA_READINESS_TIMEOUT_MS` | `30000` (30s) | Max wait for Baxia SDK readiness per token mint (`chrome-error://` pages abort instantly); clamped ≥5000 |
 | `SF_QWEN_BAXIA_VERSION` | `2.5.37` | Baxia `bx-v` version |
 | `SF_QWEN_BAXIA_PRE_WARM` | `true` | Eagerly fetch the first token at startup (exit 1 on failure) |
 | `SF_QWEN_BAXIA_FALLBACK` | `false` | Return last-known token on fetch failure |

--- a/packages/qwen-proxy/docker/docker-compose.yml
+++ b/packages/qwen-proxy/docker/docker-compose.yml
@@ -32,6 +32,7 @@ services:
       # - SF_QWEN_BAXIA_CACHE_TTL_MS=1500000
       # Optional — eagerly warm the first Baxia token at startup (default true):
       # - SF_QWEN_BAXIA_PRE_WARM=true
+      # - SF_QWEN_BAXIA_READINESS_TIMEOUT_MS=30000
     restart: unless-stopped
     # healthcheck lives in the Dockerfile
 

--- a/packages/qwen-proxy/src/config/load.ts
+++ b/packages/qwen-proxy/src/config/load.ts
@@ -45,6 +45,7 @@ export async function loadQwenProxyConfig(
       baxiaVersion: env.SF_QWEN_BAXIA_VERSION || "2.5.37",
       preWarm: env.SF_QWEN_BAXIA_PRE_WARM !== "false",
       fallback: env.SF_QWEN_BAXIA_FALLBACK === "true",
+      readinessTimeoutMs: Math.max(5_000, parseIntEnv(env.SF_QWEN_BAXIA_READINESS_TIMEOUT_MS, 30_000)),
     },
   };
 }

--- a/packages/qwen-proxy/src/config/types.ts
+++ b/packages/qwen-proxy/src/config/types.ts
@@ -4,6 +4,7 @@ export interface BaxiaConfig {
   baxiaVersion: string;
   preWarm: boolean;
   fallback: boolean;
+  readinessTimeoutMs: number; // SF_QWEN_BAXIA_READINESS_TIMEOUT_MS  default 30000 (clamp ≥5000)
 }
 
 export interface QwenProxyConfig {

--- a/packages/qwen-proxy/src/pool/retry.ts
+++ b/packages/qwen-proxy/src/pool/retry.ts
@@ -46,6 +46,9 @@ export interface RetryDeps {
 /** Module-level sleep helper for inline empty-retry gaps. */
 function sleep(ms: number): Promise<void> { return new Promise((r) => setTimeout(r, ms)); }
 
+/** Per-request consecutive mint-failure budget. */
+const MINT_STRIKE_MAX = 2;
+
 /** The union of raw upstream chunks and the one synthetic sentinel chunk. */
 export type StreamChunk =
   | OpenAiChatChunk
@@ -130,6 +133,7 @@ export async function withPoolRetry<T>(
   const rotationMode = !!(deps.proxyPool && deps.proxyPool.size > 1);
   const useSlots = !!(deps.proxyPool?.acquire && deps.proxyPool?.release);
   let tried = 0;
+  let mintStrikes = 0;
   let inlineReminted = false;
   let slotKey: string | undefined;
 
@@ -145,6 +149,7 @@ export async function withPoolRetry<T>(
     try {
       const result = await op(id, bearer, proxy);
       deps.pool.markSuccess();
+      mintStrikes = 0;
       return result;
     } catch (err) {
       if (err instanceof AuthExpiredError) {
@@ -191,7 +196,20 @@ export async function withPoolRetry<T>(
           error: String(err).slice(0, 300),
           errorCause: err instanceof Error && err.cause ? String(err.cause).slice(0, 300) : undefined,
           errorName: err instanceof Error ? err.constructor.name : typeof err,
+          ...(err instanceof TokenMintError ? { mintCause: err.cause, mintStrikes } : {}),
         });
+        if (err instanceof TokenMintError) {
+          mintStrikes++;
+          if (mintStrikes >= MINT_STRIKE_MAX) {
+            deps.log.warn("mint failures exhausted — flat cooldown + 429", { strikes: mintStrikes, size: deps.proxyPool!.size });
+            await deps.pool.markEmptyAndSwitch(id, deps.config.emptyCooldownMs);
+            await sleep(deps.config.emptyCooldownMs);
+            throw new RateLimitError(
+              "token mint failed after 2 consecutive attempts (global egress condition) — cooling down",
+              { status: 429, retryAfterMs: deps.config.emptyCooldownMs },
+            );
+          }
+        }
         if (tried < deps.proxyPool!.size) {
           const next = await rotateWithSlot(deps, slotKey ?? proxy);
           slotKey = useSlots ? next : undefined;

--- a/packages/qwen-proxy/src/pool/retry.ts
+++ b/packages/qwen-proxy/src/pool/retry.ts
@@ -284,6 +284,7 @@ export async function* withPoolRetryStream(
   const rotationMode = !!(deps.proxyPool && deps.proxyPool.size > 1);
   const useSlots = !!(deps.proxyPool?.acquire && deps.proxyPool?.release);
   let tried = 0;
+  let mintStrikes = 0;
   let inlineReminted = false;
   let slotKey: string | undefined;
 
@@ -327,6 +328,7 @@ export async function* withPoolRetryStream(
       } else {
         // Clean end — flush remaining buffer
         deps.pool.markSuccess();
+        mintStrikes = 0;
         yield* buffer;
         return;
       }
@@ -372,7 +374,20 @@ export async function* withPoolRetryStream(
           error: String(err).slice(0, 300),
           errorCause: err instanceof Error && err.cause ? String(err.cause).slice(0, 300) : undefined,
           errorName: err instanceof Error ? err.constructor.name : typeof err,
+          ...(err instanceof TokenMintError ? { mintCause: err.cause, mintStrikes } : {}),
         });
+        if (err instanceof TokenMintError) {
+          mintStrikes++;
+          if (mintStrikes >= MINT_STRIKE_MAX) {
+            deps.log.warn("mint failures exhausted — flat cooldown + sentinel", { strikes: mintStrikes, size: deps.proxyPool!.size });
+            deps.pool
+              .markEmptyAndSwitch(id, deps.config.emptyCooldownMs)
+              .catch(() => deps.log.error("background markEmptyAndSwitch failed"));
+            await sleep(deps.config.emptyCooldownMs); // awaited — the in-process storm gate
+            yield { done: true, extra: { rateLimited: true } };
+            return;
+          }
+        }
         if (tried < deps.proxyPool!.size) {
           const next = await rotateWithSlot(deps, slotKey ?? proxy);
           slotKey = useSlots ? next : undefined;

--- a/packages/qwen-proxy/src/pool/retry.ts
+++ b/packages/qwen-proxy/src/pool/retry.ts
@@ -1,5 +1,5 @@
 import type { OpenAiChatChunk } from "../upstream/client";
-import { RateLimitError, AuthExpiredError, EmptyCompletionError, NetworkError, ServerError, ClientError, UnknownError } from "../upstream/errors";
+import { TokenMintError, RateLimitError, AuthExpiredError, EmptyCompletionError, NetworkError, ServerError, ClientError, UnknownError } from "../upstream/errors";
 import { redactProxyKey } from "../upstream/proxy-bridge";
 import type { PoolLike } from "./types";
 import type { RequestThrottle } from "./throttle";
@@ -468,6 +468,7 @@ function hasPayload(chunk: OpenAiChatChunk): boolean {
  * Non-Error → false (not rotatable).
  */
 export function isRotationTrigger(err: unknown): boolean {
+  if (err instanceof TokenMintError) return true; // rotatable (single bad proxy skipped) — but budgeted ≤2/request by the wrappers
   if (err instanceof EmptyCompletionError) return true;
   if (err instanceof NetworkError) return true;
   if (err instanceof ServerError) return true;

--- a/packages/qwen-proxy/src/pool/retry.ts
+++ b/packages/qwen-proxy/src/pool/retry.ts
@@ -91,7 +91,7 @@ async function rotateWithSlot(deps: RetryDeps, current: string | undefined): Pro
 async function emptyBurnStep(
   deps: RetryDeps,
   opts: { proxy: string | undefined; tried: number; inlineReminted: boolean },
-): Promise<{ action: "remint" } | { action: "rotate"; proxy: string | undefined } | { action: "all-burned" }> {
+): Promise<{ action: "remint" } | { action: "rotate"; proxy: string | undefined } | { action: "all-burned" } | { action: "mint-failed"; error: unknown }> {
   const pool = deps.proxyPool!;
   deps.log.warn("[rotation-debug] empty completion — walking", {
     proxy: redactProxyKey(opts.proxy),
@@ -106,11 +106,7 @@ async function emptyBurnStep(
     try {
       await deps.scheduler.refreshBaxiaToken?.(opts.proxy);
     } catch (e) {
-      deps.log.error("baxia inline re-mint failed — rotating", { error: String(e), proxy: redactProxyKey(opts.proxy) });
-      if (opts.tried < pool.size - 1) {
-        return { action: "rotate", proxy: await rotateWithSlot(deps, opts.proxy) };
-      }
-      return { action: "all-burned" };
+      return { action: "mint-failed", error: e };
     }
     return { action: "remint" };
   }
@@ -166,6 +162,31 @@ export async function withPoolRetry<T>(
         const allowRemint = !inlineReminted;
         const step = await emptyBurnStep(deps, { proxy, tried, inlineReminted });
         if (allowRemint) inlineReminted = true; // an ATTEMPT consumes the one-per-request allowance
+        // Handle inline re-mint failure (resolution #3 — every mint failure counts)
+        if (step.action === "mint-failed") {
+          if (step.error instanceof TokenMintError) {
+            mintStrikes++;
+            deps.log.warn("baxia inline re-mint failed (mint)", { cause: step.error.cause, mintStrikes, proxy: redactProxyKey(proxy) });
+            if (mintStrikes >= MINT_STRIKE_MAX) {
+              deps.log.warn("mint failures exhausted — flat cooldown + 429", { strikes: mintStrikes, size: deps.proxyPool!.size });
+              await deps.pool.markEmptyAndSwitch(id, deps.config.emptyCooldownMs);
+              await sleep(deps.config.emptyCooldownMs);
+              throw new RateLimitError(
+                "token mint failed after 2 consecutive attempts (global egress condition) — cooling down",
+                { status: 429, retryAfterMs: deps.config.emptyCooldownMs },
+              );
+            }
+          } else {
+            deps.log.error("baxia inline re-mint failed — rotating", { error: String(step.error), proxy: redactProxyKey(proxy) });
+          }
+          if (tried < deps.proxyPool!.size - 1) {
+            tried += 1;
+            const next = await rotateWithSlot(deps, slotKey ?? proxy);
+            slotKey = useSlots ? next : undefined;
+            continue;
+          }
+          // else fall through to the existing all-burned path below
+        }
         if (step.action === "remint") {
           continue; // retry the SAME proxy with the fresh token
         }
@@ -349,6 +370,31 @@ export async function* withPoolRetryStream(
         const allowRemint = !inlineReminted;
         const step = await emptyBurnStep(deps, { proxy, tried, inlineReminted });
         if (allowRemint) inlineReminted = true; // an ATTEMPT consumes the one-per-request allowance
+        // Handle inline re-mint failure (resolution #3 — every mint failure counts)
+        if (step.action === "mint-failed") {
+          if (step.error instanceof TokenMintError) {
+            mintStrikes++;
+            deps.log.warn("baxia inline re-mint failed (mint)", { cause: step.error.cause, mintStrikes, proxy: redactProxyKey(proxy) });
+            if (mintStrikes >= MINT_STRIKE_MAX) {
+              deps.log.warn("mint failures exhausted — flat cooldown + sentinel", { strikes: mintStrikes, size: deps.proxyPool!.size });
+              deps.pool
+                .markEmptyAndSwitch(id, deps.config.emptyCooldownMs)
+                .catch(() => deps.log.error("background markEmptyAndSwitch failed"));
+              await sleep(deps.config.emptyCooldownMs);
+              yield { done: true, extra: { rateLimited: true } };
+              return;
+            }
+          } else {
+            deps.log.error("baxia inline re-mint failed — rotating", { error: String(step.error), proxy: redactProxyKey(proxy) });
+          }
+          if (tried < deps.proxyPool!.size - 1) {
+            tried += 1;
+            const next = await rotateWithSlot(deps, slotKey ?? proxy);
+            slotKey = useSlots ? next : undefined;
+            continue;
+          }
+          // else fall through to existing all-burned path below
+        }
         if (step.action === "remint") {
           continue; // retry the SAME proxy with the fresh token
         }
@@ -409,6 +455,31 @@ export async function* withPoolRetryStream(
       const allowRemint = !inlineReminted;
       const step = await emptyBurnStep(deps, { proxy, tried, inlineReminted });
       if (allowRemint) inlineReminted = true; // an ATTEMPT consumes the one-per-request allowance
+      // Handle inline re-mint failure (resolution #3 — every mint failure counts)
+      if (step.action === "mint-failed") {
+        if (step.error instanceof TokenMintError) {
+          mintStrikes++;
+          deps.log.warn("baxia inline re-mint failed (mint)", { cause: step.error.cause, mintStrikes, proxy: redactProxyKey(proxy) });
+          if (mintStrikes >= MINT_STRIKE_MAX) {
+            deps.log.warn("mint failures exhausted — flat cooldown + sentinel", { strikes: mintStrikes, size: deps.proxyPool!.size });
+            deps.pool
+              .markEmptyAndSwitch(id, deps.config.emptyCooldownMs)
+              .catch(() => deps.log.error("background markEmptyAndSwitch failed"));
+            await sleep(deps.config.emptyCooldownMs);
+            yield { done: true, extra: { rateLimited: true } };
+            return;
+          }
+        } else {
+          deps.log.error("baxia inline re-mint failed — rotating", { error: String(step.error), proxy: redactProxyKey(proxy) });
+        }
+        if (tried < deps.proxyPool!.size - 1) {
+          tried += 1;
+          const next = await rotateWithSlot(deps, slotKey ?? proxy);
+          slotKey = useSlots ? next : undefined;
+          continue;
+        }
+        // else fall through to the existing all-burned path below
+      }
       if (step.action === "remint") {
         continue; // retry the SAME proxy with the fresh token
       }

--- a/packages/qwen-proxy/src/pool/retry.ts
+++ b/packages/qwen-proxy/src/pool/retry.ts
@@ -221,6 +221,7 @@ export async function withPoolRetry<T>(
           // else fall through to the existing all-burned path below
         }
         if (step.action === "remint") {
+          mintStrikes = 0; // successful inline re-mint resets the strike counter
           continue; // retry the SAME proxy with the fresh token
         }
         if (step.action === "rotate") {
@@ -433,6 +434,7 @@ export async function* withPoolRetryStream(
           // else fall through to existing all-burned path below
         }
         if (step.action === "remint") {
+          mintStrikes = 0; // successful inline re-mint resets the strike counter
           continue; // retry the SAME proxy with the fresh token
         }
         if (step.action === "rotate") {
@@ -526,6 +528,7 @@ export async function* withPoolRetryStream(
         // else fall through to the existing all-burned path below
       }
       if (step.action === "remint") {
+        mintStrikes = 0; // successful inline re-mint resets the strike counter
         continue; // retry the SAME proxy with the fresh token
       }
       if (step.action === "rotate") {

--- a/packages/qwen-proxy/src/pool/retry.ts
+++ b/packages/qwen-proxy/src/pool/retry.ts
@@ -82,6 +82,35 @@ async function rotateWithSlot(deps: RetryDeps, current: string | undefined): Pro
   return pool.getActive();
 }
 
+/** Mint-exhaustion path for non-stream all-burned: markEmptyAndSwitch + cooldown + 429.
+ *  Used when the rotation walk was exhausted and mint failures participated. */
+function applyMintExhaustionNonStream(
+  deps: RetryDeps,
+  id: number,
+  mintStrikes: number,
+): never {
+  deps.log.warn("mint failures exhausted walk — flat cooldown + 429", { strikes: mintStrikes, size: deps.proxyPool!.size });
+  // markEmptyAndSwitch is synchronous fire-and-forget (returns a Promise we don't await)
+  deps.pool.markEmptyAndSwitch(id, deps.config.emptyCooldownMs).catch(() => {});
+  throw new RateLimitError(
+    "token mint failed after rotation walk (global egress condition) — cooling down",
+    { status: 429, retryAfterMs: deps.config.emptyCooldownMs },
+  );
+}
+
+/** Mint-exhaustion path for stream all-burned: markEmptyAndSwitch(fire-and-forget)
+ *  + awaited cooldown sleep + sentinel. */
+async function applyMintExhaustionStream(
+  deps: RetryDeps,
+  id: number,
+  mintStrikes: number,
+): Promise<{ done: true; extra: { rateLimited: true } }> {
+  deps.log.warn("mint failures exhausted walk — flat cooldown + sentinel", { strikes: mintStrikes, size: deps.proxyPool!.size });
+  deps.pool.markEmptyAndSwitch(id, deps.config.emptyCooldownMs).catch(() => {});
+  await sleep(deps.config.emptyCooldownMs);
+  return { done: true, extra: { rateLimited: true } };
+}
+
 /** Rotation-mode empty-completion burn recovery (Q1=B):
  *  1. log the walk attempt (redacted proxy, tried/size, token age)
  *  2. evict the proxy's burned token
@@ -199,9 +228,11 @@ export async function withPoolRetry<T>(
         }
         // All proxies burned — cooldown + refresh active token (change #2, Q3=A) + 429
         tried += 1;
+        if (mintStrikes > 0) {
+          applyMintExhaustionNonStream(deps, id, mintStrikes);
+        }
         const { emptyCooldownMs } = deps.config;
         deps.log.warn("[rotation-debug] ALL burned (non-stream)", { size: deps.proxyPool!.size, lastError: String(err).slice(0, 300) });
-        await sleep(emptyCooldownMs);
         await bestEffortRefresh(deps, proxy);
         throw new RateLimitError(
           "all proxies exhausted after rotation retries",
@@ -239,9 +270,11 @@ export async function withPoolRetry<T>(
           continue;
         }
         // All proxies burned — cooldown + refresh active token (change #2) + 429
+        if (mintStrikes > 0) {
+          applyMintExhaustionNonStream(deps, id, mintStrikes);
+        }
         const { emptyCooldownMs } = deps.config;
         deps.log.warn("[rotation-debug] ALL burned (non-stream)", { size: deps.proxyPool!.size, lastError: String(err).slice(0, 300) });
-        await sleep(emptyCooldownMs);
         await bestEffortRefresh(deps, proxy);
         throw new RateLimitError(
           "all proxies exhausted after rotation retries",
@@ -406,6 +439,10 @@ export async function* withPoolRetryStream(
           continue;
         }
         tried += 1;
+        if (mintStrikes > 0) {
+          yield await applyMintExhaustionStream(deps, id, mintStrikes);
+          return;
+        }
         deps.log.warn("rotation: all proxies burned (empty) — sentinel", { size: deps.proxyPool!.size });
         await bestEffortRefresh(deps, proxy);
         yield { done: true, extra: { rateLimited: true } };
@@ -442,6 +479,10 @@ export async function* withPoolRetryStream(
           continue;
         }
         // All proxies burned — refresh the active proxy's token (change #2, Q3=A), then sentinel
+        if (mintStrikes > 0) {
+          yield await applyMintExhaustionStream(deps, id, mintStrikes);
+          return;
+        }
         deps.log.warn("rotation: all proxies burned (error) — sentinel", { size: deps.proxyPool!.size, lastError: String(err).slice(0, 300) });
         await bestEffortRefresh(deps, proxy);
         yield { done: true, extra: { rateLimited: true } };
@@ -492,6 +533,10 @@ export async function* withPoolRetryStream(
       }
       // All proxies burned — refresh the active proxy's token, then sentinel (change #2, Q3=A)
       tried += 1;
+      if (mintStrikes > 0) {
+        yield await applyMintExhaustionStream(deps, id, mintStrikes);
+        return;
+      }
       deps.log.warn("rotation: all proxies burned (empty) — sentinel", { size: deps.proxyPool!.size });
       await bestEffortRefresh(deps, proxy);
       yield { done: true, extra: { rateLimited: true } };

--- a/packages/qwen-proxy/src/pool/retry.ts
+++ b/packages/qwen-proxy/src/pool/retry.ts
@@ -66,15 +66,17 @@ async function bestEffortRefresh(
   }
 }
 
-/** Slot-aware proxy hand-off on rotation: advance the head, acquire the new
- *  head's slot (sticky-first, skips busy proxies), THEN release the old slot so
- *  the burned proxy is not handed to another request mid-flight. */
+/** Slot-aware proxy hand-off on rotation: release the current slot FIRST,
+ *  THEN acquire the new head's slot. Releasing first avoids a deadlock when all
+ *  slots are held by concurrently-rotating requests (release-before-acquire).
+ *  The momentary no-held-slot state is safe — slot bookkeeping only, no
+ *  invariant requires continuous holding. */
 async function rotateWithSlot(deps: RetryDeps, current: string | undefined): Promise<string | undefined> {
   const pool = deps.proxyPool!;
   pool.rotate();
   if (typeof pool.acquire === "function" && typeof pool.release === "function") {
-    const next = await pool.acquire();
     if (current !== undefined) pool.release(current);
+    const next = await pool.acquire();
     return next;
   }
   return pool.getActive();

--- a/packages/qwen-proxy/src/pool/retry.ts
+++ b/packages/qwen-proxy/src/pool/retry.ts
@@ -36,6 +36,8 @@ export interface RetryDeps {
   throttle?: RequestThrottle;
   /** Optional proxy pool for SOCKS5 rotation mode (S-M2). */
   proxyPool?: ProxyPoolLike;
+  /** Injectable cooldown sleep for mint-exhaustion paths (default: module sleep). */
+  cooldownSleep?: (ms: number) => Promise<void>;
   log: {
     info: (msg: string, ctx?: unknown) => void;
     warn: (msg: string, ctx?: unknown) => void;
@@ -107,7 +109,7 @@ async function applyMintExhaustionStream(
 ): Promise<{ done: true; extra: { rateLimited: true } }> {
   deps.log.warn("mint failures exhausted walk — flat cooldown + sentinel", { strikes: mintStrikes, size: deps.proxyPool!.size });
   deps.pool.markEmptyAndSwitch(id, deps.config.emptyCooldownMs).catch(() => {});
-  await sleep(deps.config.emptyCooldownMs);
+  await (deps.cooldownSleep ?? sleep)(deps.config.emptyCooldownMs);
   return { done: true, extra: { rateLimited: true } };
 }
 
@@ -201,7 +203,7 @@ export async function withPoolRetry<T>(
             if (mintStrikes >= MINT_STRIKE_MAX) {
               deps.log.warn("mint failures exhausted — flat cooldown + 429", { strikes: mintStrikes, size: deps.proxyPool!.size });
               await deps.pool.markEmptyAndSwitch(id, deps.config.emptyCooldownMs);
-              await sleep(deps.config.emptyCooldownMs);
+              await (deps.cooldownSleep ?? sleep)(deps.config.emptyCooldownMs);
               throw new RateLimitError(
                 "token mint failed after 2 consecutive attempts (global egress condition) — cooling down",
                 { status: 429, retryAfterMs: deps.config.emptyCooldownMs },
@@ -257,7 +259,7 @@ export async function withPoolRetry<T>(
           if (mintStrikes >= MINT_STRIKE_MAX) {
             deps.log.warn("mint failures exhausted — flat cooldown + 429", { strikes: mintStrikes, size: deps.proxyPool!.size });
             await deps.pool.markEmptyAndSwitch(id, deps.config.emptyCooldownMs);
-            await sleep(deps.config.emptyCooldownMs);
+            await (deps.cooldownSleep ?? sleep)(deps.config.emptyCooldownMs);
             throw new RateLimitError(
               "token mint failed after 2 consecutive attempts (global egress condition) — cooling down",
               { status: 429, retryAfterMs: deps.config.emptyCooldownMs },
@@ -415,7 +417,7 @@ export async function* withPoolRetryStream(
               deps.pool
                 .markEmptyAndSwitch(id, deps.config.emptyCooldownMs)
                 .catch(() => deps.log.error("background markEmptyAndSwitch failed"));
-              await sleep(deps.config.emptyCooldownMs);
+              await (deps.cooldownSleep ?? sleep)(deps.config.emptyCooldownMs);
               yield { done: true, extra: { rateLimited: true } };
               return;
             }
@@ -468,7 +470,7 @@ export async function* withPoolRetryStream(
             deps.pool
               .markEmptyAndSwitch(id, deps.config.emptyCooldownMs)
               .catch(() => deps.log.error("background markEmptyAndSwitch failed"));
-            await sleep(deps.config.emptyCooldownMs); // awaited — the in-process storm gate
+            await (deps.cooldownSleep ?? sleep)(deps.config.emptyCooldownMs); // awaited — the in-process storm gate
             yield { done: true, extra: { rateLimited: true } };
             return;
           }
@@ -508,7 +510,7 @@ export async function* withPoolRetryStream(
             deps.pool
               .markEmptyAndSwitch(id, deps.config.emptyCooldownMs)
               .catch(() => deps.log.error("background markEmptyAndSwitch failed"));
-            await sleep(deps.config.emptyCooldownMs);
+            await (deps.cooldownSleep ?? sleep)(deps.config.emptyCooldownMs);
             yield { done: true, extra: { rateLimited: true } };
             return;
           }

--- a/packages/qwen-proxy/src/server/app.ts
+++ b/packages/qwen-proxy/src/server/app.ts
@@ -36,6 +36,7 @@ import {
   ServerError,
   NetworkError,
   UnknownError,
+  TokenMintError,
 } from "../upstream/errors";
 
 export interface AppDeps {
@@ -89,6 +90,11 @@ export function createApp(deps: AppDeps): OpenAPIHono {
       return isAnthropic
         ? anthropicError(c, 502, undefined, err.message)
         : openaiError(c, 502, err.message);
+    }
+    if (err instanceof TokenMintError) {
+      return isAnthropic
+        ? anthropicError(c, 503, undefined, err.message)
+        : openaiError(c, 503, err.message);
     }
     if (err instanceof NetworkError) {
       return isAnthropic

--- a/packages/qwen-proxy/src/upstream/baxia-token.ts
+++ b/packages/qwen-proxy/src/upstream/baxia-token.ts
@@ -31,6 +31,7 @@ export interface BaxiaTokenManagerConfig {
   log: Logger;
   /** Optional bridge for proxy-affine token generation (S-M1-7). */
   bridge?: { getPort(): number; setUpstream(key: string): void };
+  readinessTimeoutMs?: number;
   now?: () => number;
   spawn?: typeof import("node:child_process").spawn;
   WebSocketCtor?: typeof WebSocket;
@@ -93,6 +94,7 @@ export class BaxiaTokenManager {
   private lastUsedProxy: string = "";
   private refreshTimer: ReturnType<typeof setInterval> | null = null;
   private static readonly DIRECT_KEY = "";
+  private readonly readinessTimeoutMs: number;
   // Global spawn mutex — serializes all doRefresh calls
   private spawnChain: Promise<void> = Promise.resolve();
   // Optional bridge for proxy-affine token generation (S-M1-7)
@@ -105,6 +107,7 @@ export class BaxiaTokenManager {
     this._fetcher = config.fetcher ?? globalThis.fetch;
     this._sleep = config.sleep ?? ((ms) => new Promise((r) => setTimeout(r, ms)));
     this.bridge = config.bridge;
+    this.readinessTimeoutMs = Math.max(5_000, config.readinessTimeoutMs ?? 30_000);
   }
 
   /** Set the bridge for proxy-affine token generation (S-M1-7 / S-M2-2). */
@@ -370,7 +373,8 @@ export class BaxiaTokenManager {
           | { uid: string; fy: string; cookies: string }
           | null = null;
         let lastPageState = "";
-        for (let i = 0; i < 60; i++) {
+        const pollMax = Math.ceil(this.readinessTimeoutMs / 500);
+        for (let i = 0; i < pollMax; i++) {
           await this._sleep(500); // sleep first (qwen2api ordering — lets the SDK init)
           try {
             // Every 10th poll (~5s), capture the page state — reveals CAPTCHA
@@ -416,12 +420,13 @@ export class BaxiaTokenManager {
         }
 
         if (!baxiaData) {
-          this.config.log.error("[baxia-debug] readiness FAILED after 30s", {
+          this.config.log.error(`[baxia-debug] readiness FAILED after ${this.readinessTimeoutMs}ms`, {
             proxy: redactProxyKey(proxy),
             lastPage: lastPageState.slice(0, 300),
           });
-          throw new Error(
-            "window.__baxia__ tokens not available within 30s",
+          throw new TokenMintError(
+            "not-ready",
+            `window.__baxia__ not ready within ${this.readinessTimeoutMs}ms (page loaded, SDK uninitialized)`,
           );
         }
         this.config.log.info("[baxia-debug] token minted", {

--- a/packages/qwen-proxy/src/upstream/baxia-token.ts
+++ b/packages/qwen-proxy/src/upstream/baxia-token.ts
@@ -362,11 +362,11 @@ export class BaxiaTokenManager {
         // the page + SDK time to init). Cookies come from document.cookie.
         const baxiaExpr = `(function(){
   var fm = (window.__baxia__||{}).getFYModule;
-  if (!fm || !fm.fyObj) return { ready: false };
+  if (!fm || !fm.fyObj) return { ready: false, href: location.href };
   var uid='', fy='';
   try { uid = String(fm.getUidToken()); } catch(e) {}
   try { fy = String(fm.getFYToken()); } catch(e) {}
-  return { ready: true, uid: uid, fy: fy, cookie: document.cookie || '' };
+  return { ready: true, href: location.href, uid: uid, fy: fy, cookie: document.cookie || '' };
 })()`;
 
         let baxiaData:
@@ -396,11 +396,20 @@ export class BaxiaTokenManager {
             const val = result?.result?.value as
               | {
                   ready: boolean;
+                  href?: string;
                   uid?: string;
                   fy?: string;
                   cookie?: string;
                 }
               | undefined;
+            const href = typeof val?.href === "string" ? val.href : "";
+            if (href.startsWith("chrome-error://")) {
+              this.config.log.error("[baxia] mint fast-fail — chrome-error page", {
+                proxy: redactProxyKey(proxy),
+                href: href.slice(0, 120),
+              });
+              throw new TokenMintError("egress", "page load failed (chrome-error page) — egress unreachable");
+            }
             if (
               val?.ready &&
               typeof val.uid === "string" &&
@@ -414,7 +423,8 @@ export class BaxiaTokenManager {
               };
               break;
             }
-          } catch {
+          } catch (e) {
+            if (e instanceof TokenMintError) throw e;
             // evaluation failed, retry
           }
         }

--- a/packages/qwen-proxy/src/upstream/baxia-token.ts
+++ b/packages/qwen-proxy/src/upstream/baxia-token.ts
@@ -8,7 +8,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { spawn as nodeSpawn } from "node:child_process";
-import { NetworkError } from "./errors";
+import { NetworkError, TokenMintError } from "./errors";
 import { redactProxyKey } from "./proxy-bridge";
 import type { Logger } from "../server/logger";
 
@@ -138,7 +138,8 @@ export class BaxiaTokenManager {
       if (fs.existsSync(c)) return c;
     }
 
-    throw new Error(
+    throw new TokenMintError(
+      "egress",
       "Chrome not found — set config.chromePath or CHROME_PATH env",
     );
   }
@@ -182,7 +183,16 @@ export class BaxiaTokenManager {
       args.unshift(`--proxy-server=${proxyServerUrl}`);
       args.unshift("--host-resolver-rules=MAP * ~NOTFOUND, EXCLUDE 127.0.0.1");
     }
-    const child = this._spawn(exe, args, { stdio: "ignore", detached: true });
+    const child = (() => {
+      try {
+        return this._spawn(exe, args, { stdio: "ignore", detached: true });
+      } catch (e) {
+        throw new TokenMintError(
+          "egress",
+          `chromium spawn failed: ${e instanceof Error ? e.message : String(e)}`,
+        );
+      }
+    })();
     return { child, port };
   }
 
@@ -324,7 +334,8 @@ export class BaxiaTokenManager {
       }
 
       if (!wsUrl) {
-        throw new NetworkError(
+        throw new TokenMintError(
+          "egress",
           "Chrome /json/list never returned a page (40×250ms)",
         );
       }

--- a/packages/qwen-proxy/src/upstream/baxia-token.ts
+++ b/packages/qwen-proxy/src/upstream/baxia-token.ts
@@ -8,7 +8,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { spawn as nodeSpawn } from "node:child_process";
-import { NetworkError, TokenMintError } from "./errors";
+import { TokenMintError } from "./errors";
 import { redactProxyKey } from "./proxy-bridge";
 import type { Logger } from "../server/logger";
 
@@ -246,10 +246,10 @@ export class BaxiaTokenManager {
       openResolve();
     });
     ws.addEventListener("error", () =>
-      rejectAll(new NetworkError("cdp ws error")),
+      rejectAll(new TokenMintError("egress", "cdp ws error")),
     );
     ws.addEventListener("close", () =>
-      rejectAll(new Error("cdp ws closed")),
+      rejectAll(new TokenMintError("egress", "cdp ws closed")),
     );
 
     ws.addEventListener("message", (ev: any) => {

--- a/packages/qwen-proxy/src/upstream/baxia-token.ts
+++ b/packages/qwen-proxy/src/upstream/baxia-token.ts
@@ -386,7 +386,7 @@ export class BaxiaTokenManager {
                   returnByValue: true,
                 });
                 lastPageState = String((st?.result?.value as string) ?? "");
-                this.config.log.warn("[baxia-debug] readiness poll", { poll: i, page: lastPageState.slice(0, 300) });
+                this.config.log.info("[baxia-debug] readiness poll", { poll: i, page: lastPageState.slice(0, 300) });
               } catch { /* page evaluating mid-nav */ }
             }
             const result = await cdp.send("Runtime.evaluate", {
@@ -431,6 +431,7 @@ export class BaxiaTokenManager {
 
         if (!baxiaData) {
           this.config.log.error(`[baxia-debug] readiness FAILED after ${this.readinessTimeoutMs}ms`, {
+            cause: "not-ready",
             proxy: redactProxyKey(proxy),
             lastPage: lastPageState.slice(0, 300),
           });
@@ -550,6 +551,9 @@ export class BaxiaTokenManager {
       this.lastUsedProxy = key; // SUCCESS only
       return tokens;
     } catch (e) {
+      if (e instanceof TokenMintError) {
+        this.config.log.error("[baxia] token mint failed", { cause: e.cause, proxy: redactProxyKey(proxy), message: e.message });
+      }
       const prev = this.proxyCache.get(key);
       this.proxyCache.set(key, {
         tokens: prev?.tokens ?? null,

--- a/packages/qwen-proxy/src/upstream/baxia-token.ts
+++ b/packages/qwen-proxy/src/upstream/baxia-token.ts
@@ -354,7 +354,7 @@ export class BaxiaTokenManager {
         // Navigate to chat.qwen.ai
         await cdp.send("Page.navigate", { url: this.config.chatUrl });
 
-        // Poll for window.__baxia__.getFYModule to be READY (60 × 500ms = 30s max).
+        // Poll for window.__baxia__.getFYModule to be READY (ceil(readinessTimeoutMs/500) polls, default 30s → 60 polls).
         // Mirrors qwen2api scripts/baxia-token.js: getFYModule is a function-OBJECT
         // whose methods (getUidToken/getFYToken) + fyObj property are attached by the
         // SDK once ready — so DO NOT call getFYModule(); read fm.fyObj/fm.getUidToken()

--- a/packages/qwen-proxy/src/upstream/errors.ts
+++ b/packages/qwen-proxy/src/upstream/errors.ts
@@ -50,3 +50,18 @@ export class UnknownError extends QwenUpstreamError {
 export class EmptyCompletionError extends QwenUpstreamError {
   readonly retryable = true;
 }
+
+export type TokenMintCause = "egress" | "not-ready";
+
+/** Baxia token MINT failure (spawn/readiness). cause "egress" = page never
+ *  loaded / spawn infra failure; "not-ready" = page loaded, Baxia SDK never
+ *  initialized within the readiness timeout. Extends NetworkError: retryable,
+ *  rotatable, 503-class. */
+export class TokenMintError extends NetworkError {
+  readonly cause: TokenMintCause; // narrowed shadow of Error.cause
+  constructor(cause: TokenMintCause, message: string, opts?: { status?: number; retryAfterMs?: number }) {
+    super(message, opts);
+    this.cause = cause;
+    this.name = "TokenMintError";
+  }
+}

--- a/packages/qwen-proxy/tests/config.test.ts
+++ b/packages/qwen-proxy/tests/config.test.ts
@@ -93,6 +93,7 @@ describe("config", () => {
         baxiaVersion: "2.5.37",
         preWarm: true,
         fallback: false,
+        readinessTimeoutMs: 30_000,
       });
     });
 
@@ -103,6 +104,34 @@ describe("config", () => {
       });
       expect(config.baxia.chromePath).toBe("/usr/local/bin/chromium");
       expect(config.baxia.baxiaVersion).toBe("9.9.9");
+    });
+
+    it("SF_QWEN_BAXIA_READINESS_TIMEOUT_MS=8000 overrides", async () => {
+      const config = await loadQwenProxyConfig({
+        SF_QWEN_BAXIA_READINESS_TIMEOUT_MS: "8000",
+      });
+      expect(config.baxia.readinessTimeoutMs).toBe(8_000);
+    });
+
+    it("SF_QWEN_BAXIA_READINESS_TIMEOUT_MS non-numeric → default 30000", async () => {
+      const config = await loadQwenProxyConfig({
+        SF_QWEN_BAXIA_READINESS_TIMEOUT_MS: "abc",
+      });
+      expect(config.baxia.readinessTimeoutMs).toBe(30_000);
+    });
+
+    it("SF_QWEN_BAXIA_READINESS_TIMEOUT_MS empty → default 30000", async () => {
+      const config = await loadQwenProxyConfig({
+        SF_QWEN_BAXIA_READINESS_TIMEOUT_MS: "",
+      });
+      expect(config.baxia.readinessTimeoutMs).toBe(30_000);
+    });
+
+    it("SF_QWEN_BAXIA_READINESS_TIMEOUT_MS=3000 clamps to 5000", async () => {
+      const config = await loadQwenProxyConfig({
+        SF_QWEN_BAXIA_READINESS_TIMEOUT_MS: "3000",
+      });
+      expect(config.baxia.readinessTimeoutMs).toBe(5_000);
     });
   });
 

--- a/packages/qwen-proxy/tests/errors.test.ts
+++ b/packages/qwen-proxy/tests/errors.test.ts
@@ -8,6 +8,7 @@ import {
   UnknownError,
   QwenUpstreamError,
   EmptyCompletionError,
+  TokenMintError,
 } from "../src/upstream/errors";
 
 describe("error classes", () => {
@@ -52,5 +53,27 @@ describe("EmptyCompletionError", () => {
   it("has status undefined (semantic, not HTTP-classified)", () => {
     const err = new EmptyCompletionError("empty");
     expect(err.status).toBeUndefined();
+  });
+});
+
+describe("TokenMintError", () => {
+  it("cause=\"egress\" — retryable, extends NetworkError, name set", () => {
+    const err = new TokenMintError("egress", "boom");
+    expect(err.name).toBe("TokenMintError");
+    expect(err.message).toBe("boom");
+    expect(err.cause).toBe("egress");
+    expect(err.retryable).toBe(true);
+    expect(err).toBeInstanceOf(NetworkError);
+    expect(err).toBeInstanceOf(QwenUpstreamError);
+  });
+
+  it("cause=\"not-ready\" — retryable, extends NetworkError, name set", () => {
+    const err = new TokenMintError("not-ready", "not ready msg");
+    expect(err.name).toBe("TokenMintError");
+    expect(err.message).toBe("not ready msg");
+    expect(err.cause).toBe("not-ready");
+    expect(err.retryable).toBe(true);
+    expect(err).toBeInstanceOf(NetworkError);
+    expect(err).toBeInstanceOf(QwenUpstreamError);
   });
 });

--- a/packages/qwen-proxy/tests/health.test.ts
+++ b/packages/qwen-proxy/tests/health.test.ts
@@ -32,7 +32,7 @@ function makeStubDeps(): AppDeps {
       proxyCountriesRaw: "",
       timeoutMs: 60_000,
       adminKey: undefined,
-      baxia: { chromePath: undefined, cacheTtlMs: 1_500_000, baxiaVersion: "2.5.37", preWarm: false, fallback: false },
+      baxia: { chromePath: undefined, cacheTtlMs: 1_500_000, baxiaVersion: "2.5.37", preWarm: false, fallback: false, readinessTimeoutMs: 30_000 },
     },
     retry: (async () => {}) as any,
     retryStream: (async function* () {}) as any,

--- a/packages/qwen-proxy/tests/pool/retry.test.ts
+++ b/packages/qwen-proxy/tests/pool/retry.test.ts
@@ -1761,3 +1761,59 @@ describe("[F2] mixed-error walk exhausts with mint strikes → mint-exhaustion c
     expect(refreshCalls).toHaveLength(0);
   });
 });
+
+// ── [F4] injectable cooldown sleep (audit fix) ───────────────────────────
+
+describe("[F4] cooldownSleep injected via RetryDeps", () => {
+  it("non-stream: 2-strike mint exhaustion calls cooldownSleep once with emptyCooldownMs", async () => {
+    const pool = new FakeProxyPool(["A", "B", "C"]);
+    const sleepCalls: number[] = [];
+    const deps = makeDeps({
+      proxyPool: pool,
+      config: { emptyCooldownMs: 42, emptyRetryMax: 99, emptyRetryGapMs: 0 },
+      cooldownSleep: async (ms: number) => { sleepCalls.push(ms); },
+      scheduler: {
+        refreshOnDemand: async () => ({ bearer: "", expiresAt: null }),
+      },
+    });
+    let callCount = 0;
+
+    await expect(
+      withPoolRetry(deps, async () => {
+        callCount++;
+        throw new TokenMintError("egress", "x");
+      }),
+    ).rejects.toThrow(RateLimitError);
+
+    expect(callCount).toBe(2); // 2nd TokenMintError hits MINT_STRIKE_MAX=2
+    expect(sleepCalls).toHaveLength(1);
+    expect(sleepCalls[0]).toBe(42); // emptyCooldownMs
+  });
+
+  it("stream: 2-strike mint exhaustion calls cooldownSleep once with emptyCooldownMs", async () => {
+    const pool = new FakeProxyPool(["A", "B", "C"]);
+    const sleepCalls: number[] = [];
+    const deps = makeDeps({
+      proxyPool: pool,
+      config: { emptyCooldownMs: 42, emptyRetryMax: 99, emptyRetryGapMs: 0 },
+      cooldownSleep: async (ms: number) => { sleepCalls.push(ms); },
+      scheduler: {
+        refreshOnDemand: async () => ({ bearer: "", expiresAt: null }),
+      },
+    });
+    let callCount = 0;
+
+    async function* op(): AsyncIterable<OpenAiChatChunk> {
+      callCount++;
+      throw new TokenMintError("egress", "x");
+    }
+
+    const chunks = await collectChunks(withPoolRetryStream(deps, op));
+    expect(callCount).toBe(2); // 2nd TokenMintError hits MINT_STRIKE_MAX=2
+    expect(chunks).toHaveLength(1);
+    expect("done" in chunks[0] && (chunks[0] as any).done).toBe(true);
+    expect("done" in chunks[0] && (chunks[0] as any).extra?.rateLimited).toBe(true);
+    expect(sleepCalls).toHaveLength(1);
+    expect(sleepCalls[0]).toBe(42); // emptyCooldownMs
+  });
+});

--- a/packages/qwen-proxy/tests/pool/retry.test.ts
+++ b/packages/qwen-proxy/tests/pool/retry.test.ts
@@ -331,6 +331,120 @@ describe("withPoolRetry — rotation mode", () => {
   });
 });
 
+// ── mint-failure budget (non-stream) ────────────────────────────────────────
+
+describe("mint-failure budget (non-stream)", () => {
+  function mintDeps(overrides?: Partial<RetryDeps>) {
+    const markEmptyAndSwitchCalls: Array<{ id: number; ms: number }> = [];
+    const refreshCalls: string[] = [];
+    const pool = new FakeProxyPool(["A", "B", "C"]);
+    const deps = makeDeps({
+      proxyPool: pool,
+      config: { emptyCooldownMs: 1, emptyRetryMax: 99, emptyRetryGapMs: 0 },
+      scheduler: {
+        refreshOnDemand: async () => ({ bearer: "", expiresAt: null }),
+        refreshBaxiaToken: async (proxy?: string) => { refreshCalls.push(proxy ?? ""); },
+      },
+      ...overrides,
+    });
+    const markSpy = deps.pool.markEmptyAndSwitch.bind(deps.pool);
+    deps.pool.markEmptyAndSwitch = async (id: number, ms: number) => {
+      markEmptyAndSwitchCalls.push({ id, ms });
+      return markSpy(id, ms);
+    };
+    return { pool, deps, markEmptyAndSwitchCalls, refreshCalls };
+  }
+
+  it("1st TokenMintError(egress) rotates → success", async () => {
+    const { pool, deps, markEmptyAndSwitchCalls } = mintDeps();
+    let callCount = 0;
+
+    const result = await withPoolRetry(deps, async (_id, _bearer, proxy?) => {
+      callCount++;
+      if (callCount === 1) throw new TokenMintError("egress", "x");
+      return `ok-${proxy}`;
+    });
+
+    expect(result).toBe("ok-B");
+    expect(callCount).toBe(2);
+    expect(pool.rotateCalls).toBe(1);
+    expect(markEmptyAndSwitchCalls).toHaveLength(0);
+  });
+
+  it("1st TokenMintError(not-ready) rotates → success", async () => {
+    const { pool, deps, markEmptyAndSwitchCalls } = mintDeps();
+    let callCount = 0;
+
+    const result = await withPoolRetry(deps, async (_id, _bearer, proxy?) => {
+      callCount++;
+      if (callCount === 1) throw new TokenMintError("not-ready", "x");
+      return `ok-${proxy}`;
+    });
+
+    expect(result).toBe("ok-B");
+    expect(callCount).toBe(2);
+    expect(pool.rotateCalls).toBe(1);
+    expect(markEmptyAndSwitchCalls).toHaveLength(0);
+  });
+
+  it("2 strikes → 429 + cooldown, NO bestEffortRefresh, exactly 2 attempts", async () => {
+    const { deps, markEmptyAndSwitchCalls, refreshCalls } = mintDeps();
+    let callCount = 0;
+
+    await expect(
+      withPoolRetry(deps, async () => {
+        callCount++;
+        throw new TokenMintError("egress", "x");
+      }),
+    ).rejects.toThrow(RateLimitError);
+
+    expect(callCount).toBe(2);
+    expect(markEmptyAndSwitchCalls).toHaveLength(1);
+    expect(refreshCalls).toHaveLength(0); // NO bestEffortRefresh on mint-exhaustion
+  });
+
+  it("counter is per-request", async () => {
+    const { deps, markEmptyAndSwitchCalls } = mintDeps();
+    let callCount = 0;
+    let firstDone = false;
+
+    // Call 1: strike then success → ok
+    const result1 = await withPoolRetry(deps, async (_id, _bearer, proxy?) => {
+      callCount++;
+      if (!firstDone && callCount === 1) throw new TokenMintError("egress", "x");
+      firstDone = true;
+      return `ok-${proxy}`;
+    });
+    expect(result1).toMatch(/^ok-/);
+
+    // Call 2: two strikes → 429 after exactly 2 more op calls
+    let call2Count = 0;
+    await expect(
+      withPoolRetry(deps, async () => {
+        call2Count++;
+        throw new TokenMintError("egress", "x");
+      }),
+    ).rejects.toThrow(RateLimitError);
+    expect(call2Count).toBe(2);
+    expect(markEmptyAndSwitchCalls).toHaveLength(1);
+  });
+
+  it("legacy mode: TokenMintError surfaces unchanged", async () => {
+    const deps = makeDeps({ config: { emptyCooldownMs: 1, emptyRetryMax: 99, emptyRetryGapMs: 0 } });
+    // No proxyPool → legacy mode, no budget
+    let callCount = 0;
+
+    await expect(
+      withPoolRetry(deps, async () => {
+        callCount++;
+        throw new TokenMintError("egress", "mint boom");
+      }),
+    ).rejects.toBeInstanceOf(TokenMintError);
+
+    expect(callCount).toBe(1);
+  });
+});
+
 // ── withPoolRetryStream — rotation mode ─────────────────────────────────────
 
 /** Helper to build rotation-mode stream deps, reusing FakeProxyPool. */

--- a/packages/qwen-proxy/tests/pool/retry.test.ts
+++ b/packages/qwen-proxy/tests/pool/retry.test.ts
@@ -1691,3 +1691,73 @@ describe("[F1] rotateWithSlot deadlock fix", () => {
     expect(pool.released.length).toBe(4);
   }, 5000);
 });
+
+// ── [F2] mixed-error walk exhaustion (audit fix) ──────────────────────────
+
+describe("[F2] mixed-error walk exhausts with mint strikes → mint-exhaustion cooldown", () => {
+  it("non-stream: walk-exhausted with 1 mint strike → cooldown + 429, no bestEffortRefresh", async () => {
+    const pool = new FakeProxyPool(["A", "B", "C"]);
+    const markCalls: Array<{ id: number; ms: number }> = [];
+    const refreshCalls: string[] = [];
+    const deps = makeDeps({
+      proxyPool: pool,
+      config: { emptyCooldownMs: 10, emptyRetryMax: 99, emptyRetryGapMs: 0 },
+      scheduler: {
+        refreshOnDemand: async () => ({ bearer: "", expiresAt: null }),
+        refreshBaxiaToken: async (proxy?: string) => { refreshCalls.push(proxy ?? ""); },
+      },
+    });
+    const markSpy = deps.pool.markEmptyAndSwitch.bind(deps.pool);
+    deps.pool.markEmptyAndSwitch = async (id: number, ms: number) => {
+      markCalls.push({ id, ms });
+      return markSpy(id, ms);
+    };
+    let callCount = 0;
+
+    await expect(
+      withPoolRetry(deps, async () => {
+        callCount++;
+        if (callCount <= 2) throw new NetworkError("timeout");
+        throw new TokenMintError("egress", "x"); // 3rd proxy → mint strike, walk exhausted
+      }),
+    ).rejects.toThrow(RateLimitError);
+
+    expect(callCount).toBe(3); // tried all 3 proxies
+    expect(markCalls).toHaveLength(1); // markEmptyAndSwitch called on mint exhaustion
+    expect(refreshCalls).toHaveLength(0); // NO bestEffortRefresh on mint exhaustion
+  });
+
+  it("stream: walk-exhausted with 1 mint strike → cooldown + sentinel, no bestEffortRefresh", async () => {
+    const pool = new FakeProxyPool(["A", "B", "C"]);
+    const markCalls: Array<{ id: number; ms: number }> = [];
+    const refreshCalls: string[] = [];
+    const deps = makeDeps({
+      proxyPool: pool,
+      config: { emptyCooldownMs: 10, emptyRetryMax: 99, emptyRetryGapMs: 0 },
+      scheduler: {
+        refreshOnDemand: async () => ({ bearer: "", expiresAt: null }),
+        refreshBaxiaToken: async (proxy?: string) => { refreshCalls.push(proxy ?? ""); },
+      },
+    });
+    const markSpy = deps.pool.markEmptyAndSwitch.bind(deps.pool);
+    deps.pool.markEmptyAndSwitch = async (id: number, ms: number) => {
+      markCalls.push({ id, ms });
+      return markSpy(id, ms);
+    };
+    let callCount = 0;
+
+    async function* op(): AsyncIterable<OpenAiChatChunk> {
+      callCount++;
+      if (callCount <= 2) throw new NetworkError("timeout");
+      throw new TokenMintError("egress", "x");
+    }
+
+    const chunks = await collectChunks(withPoolRetryStream(deps, op));
+    expect(callCount).toBe(3);
+    expect(chunks).toHaveLength(1);
+    expect("done" in chunks[0] && (chunks[0] as any).done).toBe(true);
+    expect("done" in chunks[0] && (chunks[0] as any).extra?.rateLimited).toBe(true);
+    expect(markCalls).toHaveLength(1);
+    expect(refreshCalls).toHaveLength(0);
+  });
+});

--- a/packages/qwen-proxy/tests/pool/retry.test.ts
+++ b/packages/qwen-proxy/tests/pool/retry.test.ts
@@ -1591,3 +1591,103 @@ describe("mint-failure budget (stream)", () => {
     expect(markCalls).toHaveLength(1); // exhaustion
   });
 });
+
+// ── [F1] rotateWithSlot deadlock (audit fix) ───────────────────────────────
+
+/** A slot-aware pool that BLOCKS on acquire when every key is busy,
+ *  mirroring real ProxyPool semaphore semantics (F1 deadlock repro). */
+class FakeBlockingSlotPool implements ProxyPoolLike {
+  readonly keys: string[];
+  private head = 0;
+  private readonly busy = new Map<string, number>();
+  private readonly waiters: Array<() => void> = [];
+  readonly acquired: string[] = [];
+  readonly released: string[] = [];
+  rotateCalls = 0;
+
+  constructor(keys: string[]) {
+    this.keys = keys;
+    for (const k of keys) this.busy.set(k, 0);
+  }
+
+  get size() { return this.keys.length; }
+  getActive() { return this.keys[this.head]; }
+  rotate() {
+    this.rotateCalls++;
+    this.head = (this.head + 1) % this.keys.length;
+    return this.keys[this.head];
+  }
+
+  private freeKey(): string | undefined {
+    for (let i = 0; i < this.keys.length; i++) {
+      const k = this.keys[(this.head + i) % this.keys.length];
+      if (this.busy.get(k) === 0) return k;
+    }
+    return undefined;
+  }
+
+  acquire(): Promise<string> {
+    let k = this.freeKey();
+    if (k !== undefined) {
+      this.busy.set(k, 1);
+      this.acquired.push(k);
+      return Promise.resolve(k);
+    }
+    return new Promise<string>((resolve) => {
+      this.waiters.push(() => {
+        const kk = this.freeKey()!;
+        this.busy.set(kk, 1);
+        this.acquired.push(kk);
+        resolve(kk);
+      });
+    });
+  }
+
+  release(key: string): void {
+    this.busy.set(key, 0);
+    this.released.push(key);
+    const w = this.waiters.shift();
+    if (w) w();
+  }
+}
+
+describe("[F1] rotateWithSlot deadlock fix", () => {
+  it("rotateWithSlot does not deadlock when all slots busy (pool=[A,B] conc=2, release-before-acquire)", async () => {
+    const pool = new FakeBlockingSlotPool(["A", "B"]);
+    const deps = makeDeps({
+      proxyPool: pool,
+      config: { emptyCooldownMs: 1, emptyRetryMax: 99, emptyRetryGapMs: 0 },
+      scheduler: {
+        refreshOnDemand: async () => ({ bearer: "", expiresAt: null }),
+      },
+    });
+
+    let call1 = 0;
+    let call2 = 0;
+    const op1 = async (_id: number, _bearer: string, proxy?: string) => {
+      call1++;
+      if (call1 === 1) throw new TokenMintError("egress", "x");
+      return `ok1-${proxy}`;
+    };
+    const op2 = async (_id: number, _bearer: string, proxy?: string) => {
+      call2++;
+      if (call2 === 1) throw new TokenMintError("egress", "x");
+      return `ok2-${proxy}`;
+    };
+
+    // Both requests start concurrently — previously this deadlocked because
+    // rotateWithSlot acquired the next slot before releasing the current one.
+    const [r1, r2] = await Promise.all([
+      withPoolRetry(deps, op1),
+      withPoolRetry(deps, op2),
+    ]);
+
+    expect(r1).toContain("ok1-");
+    expect(r2).toContain("ok2-");
+    // Each rotated once (A→B or B→A) after the first TokenMintError
+    expect(pool.rotateCalls).toBe(2);
+    // 4 releases: 2 from rotateWithSlot (old key released before acquire)
+    // + 2 from the finally block (final key released on exit)
+    expect(pool.released.length).toBe(4);
+  }, 5000);
+});

--- a/packages/qwen-proxy/tests/pool/retry.test.ts
+++ b/packages/qwen-proxy/tests/pool/retry.test.ts
@@ -17,6 +17,7 @@ import {
   NetworkError,
   UnknownError,
   EmptyCompletionError,
+  TokenMintError,
 } from "../../src/upstream/errors";
 import type { OpenAiChatChunk } from "../../src/upstream/client";
 import type { Logger } from "../../src/server/logger";
@@ -151,6 +152,15 @@ describe("isRotationTrigger", () => {
 
   it("UnknownError → false (terminal)", () => {
     expect(isRotationTrigger(new UnknownError("unknown"))).toBe(false);
+  });
+
+  // TokenMintError — rotatable (both causes)
+  it("TokenMintError(egress) → true (rotatable)", () => {
+    expect(isRotationTrigger(new TokenMintError("egress", "x"))).toBe(true);
+  });
+
+  it("TokenMintError(not-ready) → true (rotatable)", () => {
+    expect(isRotationTrigger(new TokenMintError("not-ready", "x"))).toBe(true);
   });
 
   // Non-Error → false

--- a/packages/qwen-proxy/tests/pool/retry.test.ts
+++ b/packages/qwen-proxy/tests/pool/retry.test.ts
@@ -1405,3 +1405,76 @@ describe("impl-review fixes", () => {
     expect((chunks[0] as any).done).toBe(true); // all burned → sentinel
   });
 });
+
+// ── mint-failure budget (stream) ────────────────────────────────────────────
+
+describe("mint-failure budget (stream)", () => {
+  function mintStreamDeps(overrides?: Partial<RetryDeps>) {
+    const markEmptyAndSwitchCalls: Array<{ id: number; ms: number }> = [];
+    const refreshCalls: string[] = [];
+    const pool = new FakeProxyPool(["A", "B", "C"]);
+    const deps = makeDeps({
+      proxyPool: pool,
+      config: { emptyCooldownMs: 1, emptyRetryMax: 99, emptyRetryGapMs: 0 },
+      scheduler: {
+        refreshOnDemand: async () => ({ bearer: "", expiresAt: null }),
+        refreshBaxiaToken: async (proxy?: string) => { refreshCalls.push(proxy ?? ""); },
+      },
+      ...overrides,
+    });
+    const markSpy = deps.pool.markEmptyAndSwitch.bind(deps.pool);
+    deps.pool.markEmptyAndSwitch = async (id: number, ms: number) => {
+      markEmptyAndSwitchCalls.push({ id, ms });
+      return markSpy(id, ms);
+    };
+    return { pool, deps, markEmptyAndSwitchCalls, refreshCalls };
+  }
+
+  it("1st TokenMintError rotates → success", async () => {
+    const { pool, deps, markEmptyAndSwitchCalls } = mintStreamDeps();
+    let callCount = 0;
+
+    async function* op(
+      _id: number,
+      _bearer: string,
+      _proxy?: string,
+    ): AsyncIterable<OpenAiChatChunk> {
+      callCount++;
+      if (callCount === 1) throw new TokenMintError("egress", "x");
+      yield contentChunk("ok");
+      yield finishChunk("stop");
+    }
+
+    const chunks = await collectChunks(withPoolRetryStream(deps, op));
+    expect(chunks).toEqual([contentChunk("ok"), finishChunk("stop")]);
+    expect(callCount).toBe(2);
+    expect(pool.rotateCalls).toBe(1);
+    expect(markEmptyAndSwitchCalls).toHaveLength(0);
+  });
+
+  it("2 strikes → rateLimited sentinel, NO bestEffortRefresh, exactly 2 attempts", async () => {
+    const { pool, deps, markEmptyAndSwitchCalls, refreshCalls } = mintStreamDeps();
+    let callCount = 0;
+
+    async function* op(
+      _id: number,
+      _bearer: string,
+      _proxy?: string,
+    ): AsyncIterable<OpenAiChatChunk> {
+      callCount++;
+      throw new TokenMintError("egress", "x");
+    }
+
+    const chunks = await collectChunks(withPoolRetryStream(deps, op));
+    expect(callCount).toBe(2);
+    // Last chunk is the rateLimited sentinel, and it's the ONLY chunk
+    expect(chunks).toHaveLength(1);
+    const sentinel = chunks[0];
+    expect("done" in sentinel && sentinel.done).toBe(true);
+    expect("done" in sentinel && (sentinel as any).extra?.rateLimited).toBe(true);
+    expect(markEmptyAndSwitchCalls).toHaveLength(1);
+    expect(refreshCalls).toHaveLength(0); // NO bestEffortRefresh on mint-exhaustion
+    // First strike rotates (A→B), second strike exhausts
+    expect(pool.rotateCalls).toBe(1);
+  });
+});

--- a/packages/qwen-proxy/tests/pool/retry.test.ts
+++ b/packages/qwen-proxy/tests/pool/retry.test.ts
@@ -443,6 +443,77 @@ describe("mint-failure budget (non-stream)", () => {
 
     expect(callCount).toBe(1);
   });
+
+  it("EmptyCompletion → inline re-mint TokenMintError (strike 1) → op TokenMintError (strike 2) → 429", async () => {
+    const pool = new FakeProxyPool(["A", "B", "C"]);
+    const markEmptyAndSwitchCalls: Array<{ id: number; ms: number }> = [];
+    const refreshCalls: string[] = [];
+    const deps = makeDeps({
+      proxyPool: pool,
+      config: { emptyCooldownMs: 1, emptyRetryMax: 99, emptyRetryGapMs: 0 },
+      scheduler: {
+        refreshOnDemand: async () => ({ bearer: "", expiresAt: null }),
+        refreshBaxiaToken: async (proxy?: string) => {
+          refreshCalls.push(proxy ?? "");
+          throw new TokenMintError("egress", "inline mint boom");
+        },
+        evictBaxiaToken: () => {},
+      },
+    });
+    const markSpy = deps.pool.markEmptyAndSwitch.bind(deps.pool);
+    deps.pool.markEmptyAndSwitch = async (id: number, ms: number) => {
+      markEmptyAndSwitchCalls.push({ id, ms });
+      return markSpy(id, ms);
+    };
+    let callCount = 0;
+
+    await expect(
+      withPoolRetry(deps, async () => {
+        callCount++;
+        if (callCount === 1) throw new EmptyCompletionError("empty");
+        throw new TokenMintError("egress", "mint boom");
+      }),
+    ).rejects.toThrow(RateLimitError);
+
+    expect(callCount).toBe(2); // 2 op calls total
+    expect(refreshCalls).toHaveLength(1); // one inline re-mint attempt
+    expect(markEmptyAndSwitchCalls).toHaveLength(1); // exhaustion
+  });
+
+  it("non-mint inline re-mint failure → rotate, no strike", async () => {
+    const pool = new FakeProxyPool(["A", "B", "C"]);
+    const markEmptyAndSwitchCalls: Array<{ id: number; ms: number }> = [];
+    const refreshed: string[] = [];
+    const deps = makeDeps({
+      proxyPool: pool,
+      config: { emptyCooldownMs: 1, emptyRetryMax: 99, emptyRetryGapMs: 0 },
+      scheduler: {
+        refreshOnDemand: async () => ({ bearer: "", expiresAt: null }),
+        refreshBaxiaToken: async (proxy?: string) => {
+          refreshed.push(proxy ?? "");
+          throw new Error("chrome spawn failed"); // non-mint failure
+        },
+        evictBaxiaToken: () => {},
+      },
+    });
+    const markSpy = deps.pool.markEmptyAndSwitch.bind(deps.pool);
+    deps.pool.markEmptyAndSwitch = async (id: number, ms: number) => {
+      markEmptyAndSwitchCalls.push({ id, ms });
+      return markSpy(id, ms);
+    };
+    let callCount = 0;
+    const seen: string[] = [];
+
+    const result = await withPoolRetry(deps, async (_id, _bearer, proxy?) => {
+      callCount++;
+      seen.push(proxy!);
+      if (callCount <= 2) throw new EmptyCompletionError("empty"); // A empty → re-mint fail (non-mint) → rotate B → B empty → re-mint fail → rotate C
+      return `ok-${proxy}`;
+    });
+
+    expect(result).toContain("ok-");
+    expect(markEmptyAndSwitchCalls).toHaveLength(0); // no mint exhaustion
+  });
 });
 
 // ── withPoolRetryStream — rotation mode ─────────────────────────────────────
@@ -1476,5 +1547,47 @@ describe("mint-failure budget (stream)", () => {
     expect(refreshCalls).toHaveLength(0); // NO bestEffortRefresh on mint-exhaustion
     // First strike rotates (A→B), second strike exhausts
     expect(pool.rotateCalls).toBe(1);
+  });
+
+  it("EmptyCompletion → inline re-mint TokenMintError (strike 1) → op TokenMintError (strike 2) → sentinel (stream)", async () => {
+    const pool = new FakeProxyPool(["A", "B", "C"]);
+    const markCalls: Array<{ id: number; ms: number }> = [];
+    const refreshCalls: string[] = [];
+    const deps = makeDeps({
+      proxyPool: pool,
+      config: { emptyCooldownMs: 1, emptyRetryMax: 99, emptyRetryGapMs: 0 },
+      scheduler: {
+        refreshOnDemand: async () => ({ bearer: "", expiresAt: null }),
+        refreshBaxiaToken: async (proxy?: string) => {
+          refreshCalls.push(proxy ?? "");
+          throw new TokenMintError("egress", "inline mint boom");
+        },
+        evictBaxiaToken: () => {},
+      },
+    });
+    const markSpy = deps.pool.markEmptyAndSwitch.bind(deps.pool);
+    deps.pool.markEmptyAndSwitch = async (id: number, ms: number) => {
+      markCalls.push({ id, ms });
+      return markSpy(id, ms);
+    };
+    let callCount = 0;
+
+    async function* op(
+      _id: number,
+      _bearer: string,
+      _proxy?: string,
+    ): AsyncIterable<OpenAiChatChunk> {
+      callCount++;
+      if (callCount === 1) throw new EmptyCompletionError("empty");
+      throw new TokenMintError("egress", "mint boom");
+    }
+
+    const chunks = await collectChunks(withPoolRetryStream(deps, op));
+    expect(callCount).toBe(2);
+    expect(chunks).toHaveLength(1);
+    expect("done" in chunks[0] && (chunks[0] as any).done).toBe(true);
+    expect("done" in chunks[0] && (chunks[0] as any).extra?.rateLimited).toBe(true);
+    expect(refreshCalls).toHaveLength(1); // one inline re-mint attempt
+    expect(markCalls).toHaveLength(1); // exhaustion
   });
 });

--- a/packages/qwen-proxy/tests/pool/retry.test.ts
+++ b/packages/qwen-proxy/tests/pool/retry.test.ts
@@ -1817,3 +1817,57 @@ describe("[F4] cooldownSleep injected via RetryDeps", () => {
     expect(sleepCalls[0]).toBe(42); // emptyCooldownMs
   });
 });
+
+// ── [F5] mint strikes reset on successful inline re-mint (audit fix) ─────
+
+describe("[F5] mintStrikes resets on successful inline re-mint", () => {
+  it("non-stream: EmptyCompletionError → remint succeeds → 2 TokenMintErrors → 429 (3 calls, not 2)", async () => {
+    const pool = new FakeProxyPool(["A", "B", "C"]);
+    const deps = makeDeps({
+      proxyPool: pool,
+      config: { emptyCooldownMs: 10, emptyRetryMax: 99, emptyRetryGapMs: 0 },
+      scheduler: {
+        refreshOnDemand: async () => ({ bearer: "", expiresAt: null }),
+        refreshBaxiaToken: async () => {}, // succeeds — triggers reset
+      },
+    });
+    let callCount = 0;
+
+    await expect(
+      withPoolRetry(deps, async () => {
+        callCount++;
+        if (callCount === 1) throw new EmptyCompletionError("empty");
+        throw new TokenMintError("egress", "x");
+      }),
+    ).rejects.toThrow(RateLimitError);
+
+    // With reset: EmptyCompletion→remint(reset), TME(strikes=1), TME(strikes=2→429) = 3 calls.
+    // Without reset: TME(strikes=1), TME(strikes=2→429) = 2 calls.
+    expect(callCount).toBe(3);
+  });
+
+  it("stream: EmptyCompletionError → remint succeeds → 2 TokenMintErrors → 429/sentinel (3 calls, not 2)", async () => {
+    const pool = new FakeProxyPool(["A", "B", "C"]);
+    const deps = makeDeps({
+      proxyPool: pool,
+      config: { emptyCooldownMs: 10, emptyRetryMax: 99, emptyRetryGapMs: 0 },
+      scheduler: {
+        refreshOnDemand: async () => ({ bearer: "", expiresAt: null }),
+        refreshBaxiaToken: async () => {}, // succeeds — triggers reset
+      },
+    });
+    let callCount = 0;
+
+    async function* op(): AsyncIterable<OpenAiChatChunk> {
+      callCount++;
+      if (callCount === 1) throw new EmptyCompletionError("empty");
+      throw new TokenMintError("egress", "x");
+    }
+
+    const chunks = await collectChunks(withPoolRetryStream(deps, op));
+    expect(callCount).toBe(3);
+    expect(chunks).toHaveLength(1);
+    expect("done" in chunks[0] && (chunks[0] as any).done).toBe(true);
+    expect("done" in chunks[0] && (chunks[0] as any).extra?.rateLimited).toBe(true);
+  });
+});

--- a/packages/qwen-proxy/tests/server/admin-routes.test.ts
+++ b/packages/qwen-proxy/tests/server/admin-routes.test.ts
@@ -124,7 +124,7 @@ function makeStubDeps(adminKey?: string): AppDeps {
       proxyCountriesRaw: "",
       timeoutMs: 60_000,
       adminKey,
-      baxia: { chromePath: undefined, cacheTtlMs: 1_500_000, baxiaVersion: "2.5.37", preWarm: false, fallback: false },
+      baxia: { chromePath: undefined, cacheTtlMs: 1_500_000, baxiaVersion: "2.5.37", preWarm: false, fallback: false, readinessTimeoutMs: 30_000 },
     },
     retry: (async () => {}) as any,
     retryStream: (async function* () {}) as any,

--- a/packages/qwen-proxy/tests/server/app-error.test.ts
+++ b/packages/qwen-proxy/tests/server/app-error.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+import { createApp } from "../../src/server/app";
+import { openDb } from "../../src/store/db";
+import { SingleAccountPool } from "../../src/pool/single";
+import { RequestThrottle } from "../../src/pool/throttle";
+import { TokenMintError } from "../../src/upstream/errors";
+import type { AppDeps } from "../../src/server/app";
+
+const noopLog = { info: () => {}, warn: () => {}, error: () => {} };
+
+function makeStubDeps(): AppDeps {
+  const db = openDb(":memory:");
+  const pool = new SingleAccountPool({ log: noopLog });
+  return {
+    db,
+    pool,
+    client: {} as any,
+    scheduler: { refreshOnDemand: async () => ({ bearer: "", expiresAt: null }) },
+    config: {
+      host: "127.0.0.1",
+      port: 0,
+      dbPath: ":memory:",
+      emptyCooldownMs: 10_000,
+      emptyRetryMax: 3,
+      emptyRetryGapMs: 1_000,
+      minRequestGapMs: 0,
+      maxConcurrency: 1,
+      firstPayloadTimeoutMs: 30_000,
+      streamIdleTimeoutMs: 30_000,
+      apiKeyEnv: ["test-key"],
+      modelAliasesRaw: "",
+      logLevel: "info",
+      proxyCount: 0,
+      proxyUrlsRaw: "",
+      proxyCountriesRaw: "",
+      timeoutMs: 60_000,
+      adminKey: undefined,
+      baxia: { chromePath: undefined, cacheTtlMs: 1_500_000, baxiaVersion: "2.5.37", preWarm: false, fallback: false, readinessTimeoutMs: 30_000 },
+    },
+    retry: (async () => { throw new TokenMintError("egress", "mint boom"); }) as any,
+    retryStream: (async function* () {}) as any,
+    throttle: new RequestThrottle({ minGapMs: 0 }),
+    log: noopLog,
+  };
+}
+
+describe("app.onError — TokenMintError → 503", () => {
+  it("OpenAI envelope", async () => {
+    const app = createApp(makeStubDeps());
+    const res = await app.request("/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer test-key",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "qwen3-max",
+        messages: [{ role: "user", content: "hi" }],
+      }),
+    });
+
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(JSON.stringify(body)).toContain("mint boom");
+    expect(body.error).toBeDefined();
+    expect(body.error.type).toBe("server_error");
+  });
+
+  it("Anthropic envelope", async () => {
+    const app = createApp(makeStubDeps());
+    const res = await app.request("/v1/messages", {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer test-key",
+        "anthropic-version": "2023-06-01",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "qwen3-max",
+        max_tokens: 1024,
+        messages: [{ role: "user", content: "hi" }],
+      }),
+    });
+
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.type).toBe("error");
+    expect(JSON.stringify(body)).toContain("mint boom");
+  });
+});

--- a/packages/qwen-proxy/tests/start.test.ts
+++ b/packages/qwen-proxy/tests/start.test.ts
@@ -34,7 +34,7 @@ function makeStubDeps(): AppDeps {
       proxyCountriesRaw: "",
       timeoutMs: 60_000,
       adminKey: undefined,
-      baxia: { chromePath: undefined, cacheTtlMs: 1_500_000, baxiaVersion: "2.5.37", preWarm: false, fallback: false },
+      baxia: { chromePath: undefined, cacheTtlMs: 1_500_000, baxiaVersion: "2.5.37", preWarm: false, fallback: false, readinessTimeoutMs: 30_000 },
     },
     retry: (async () => {}) as any,
     retryStream: (async function* () {}) as any,

--- a/packages/qwen-proxy/tests/upstream/baxia-token.test.ts
+++ b/packages/qwen-proxy/tests/upstream/baxia-token.test.ts
@@ -310,6 +310,8 @@ describe("BaxiaTokenManager", () => {
 
       // GAP-FIX: the error handler rejects all pending CDP promises
       await expect(mgr.ensureToken()).rejects.toThrow(/cdp ws error/i);
+      await expect(mgr.ensureToken()).rejects.toBeInstanceOf(TokenMintError);
+      await expect(mgr.ensureToken()).rejects.toMatchObject({ cause: "egress" });
     });
 
     it("rejects pending on ws close (GAP-FIX)", async () => {
@@ -348,6 +350,8 @@ describe("BaxiaTokenManager", () => {
       );
 
       await expect(mgr.ensureToken()).rejects.toThrow(/cdp ws closed/i);
+      await expect(mgr.ensureToken()).rejects.toBeInstanceOf(TokenMintError);
+      await expect(mgr.ensureToken()).rejects.toMatchObject({ cause: "egress" });
     });
   });
 

--- a/packages/qwen-proxy/tests/upstream/baxia-token.test.ts
+++ b/packages/qwen-proxy/tests/upstream/baxia-token.test.ts
@@ -1423,3 +1423,95 @@ describe("baxia log redaction", () => {
     expect(spawnLog!.ctx.proxy).toBe("redact-me:1080");
   });
 });
+
+// ── mint log polish (S-M3-1) ─────────────────────────────────────────────────
+
+describe("mint log polish", () => {
+  it("readiness poll logs at info, never warn", async () => {
+    const { BaxiaTokenManager } = await import("../../src/upstream/baxia-token");
+    const infoMessages: string[] = [];
+    const warnMessages: string[] = [];
+    const log = {
+      info: (msg: string) => infoMessages.push(msg),
+      warn: (msg: string) => warnMessages.push(msg),
+      error: () => {},
+    };
+    const replyMap = new Map<string, (id: number, params: any) => any>();
+    replyMap.set("Page.enable", () => ({}));
+    replyMap.set("Runtime.enable", () => ({}));
+    replyMap.set("Page.navigate", () => ({ frameId: "f1" }));
+    replyMap.set("Runtime.evaluate", (_id, params) => {
+      if (params?.expression?.includes("__baxia__")) {
+        return { result: { type: "object", value: { ready: false, href: "https://chat.qwen.ai/" } } };
+      }
+      return { result: { type: "undefined" } };
+    });
+    const config = makeConfig({
+      spawn: vi.fn(() => ({ pid: 1, kill: vi.fn() })) as any,
+      WebSocketCtor: function (url: string) { return new FakeWebSocket(url, replyMap) as any; } as any,
+      fetcher: vi.fn(async (url: string) => {
+        if (url.includes("/json/list")) {
+          return { ok: true, json: async () => [{ type: "page", webSocketDebuggerUrl: "ws://127.0.0.1:9222/devtools/page/abc" }] };
+        }
+        return { ok: false, json: async () => ({}) };
+      }) as any,
+      sleep: () => Promise.resolve(),
+      now: vi.fn(() => 1000),
+      readinessTimeoutMs: 5000,
+      log,
+    });
+    const mgr = new BaxiaTokenManager(config);
+
+    await mgr.ensureToken({ proxy: "socks5://u:secretpw@host:1080" }).catch(() => {});
+
+    expect(warnMessages.filter((m) => m.includes("readiness poll"))).toHaveLength(0);
+    const readinessInfoCount = infoMessages.filter((m) => m.includes("readiness poll")).length;
+    expect(readinessInfoCount).toBeGreaterThan(0);
+  });
+
+  it("mint failure log.error carries cause + redacted proxy", async () => {
+    const { BaxiaTokenManager } = await import("../../src/upstream/baxia-token");
+    const records: Array<{ msg: string; ctx: any }> = [];
+    const log = {
+      info: (msg: string, ctx?: unknown) => records.push({ msg, ctx }),
+      warn: (msg: string, ctx?: unknown) => records.push({ msg, ctx }),
+      error: (msg: string, ctx?: unknown) => records.push({ msg, ctx }),
+    };
+    const replyMap = new Map<string, (id: number, params: any) => any>();
+    replyMap.set("Page.enable", () => ({}));
+    replyMap.set("Runtime.enable", () => ({}));
+    replyMap.set("Page.navigate", () => ({ frameId: "f1" }));
+    replyMap.set("Runtime.evaluate", (_id, params) => {
+      if (params?.expression?.includes("__baxia__")) {
+        return { result: { type: "object", value: { ready: false, href: "https://chat.qwen.ai/" } } };
+      }
+      return { result: { type: "undefined" } };
+    });
+    const config = makeConfig({
+      spawn: vi.fn(() => ({ pid: 1, kill: vi.fn() })) as any,
+      WebSocketCtor: function (url: string) { return new FakeWebSocket(url, replyMap) as any; } as any,
+      fetcher: vi.fn(async (url: string) => {
+        if (url.includes("/json/list")) {
+          return { ok: true, json: async () => [{ type: "page", webSocketDebuggerUrl: "ws://127.0.0.1:9222/devtools/page/abc" }] };
+        }
+        return { ok: false, json: async () => ({}) };
+      }) as any,
+      sleep: () => Promise.resolve(),
+      now: vi.fn(() => 1000),
+      readinessTimeoutMs: 5000,
+      log,
+    });
+    const mgr = new BaxiaTokenManager(config);
+    const proxy = "socks5://u:secretpw@host:1080";
+
+    await mgr.ensureToken({ proxy }).catch(() => {});
+
+    const mintFail = records.find((r) => r.msg === "[baxia] token mint failed");
+    expect(mintFail).toBeDefined();
+    expect(mintFail!.ctx.cause).toBe("not-ready");
+    expect(mintFail!.ctx.proxy).toBe("host:1080");
+    const serialized = JSON.stringify(records);
+    expect(serialized).not.toContain("u:secretpw");
+    expect(serialized).not.toContain("socks5://u:secretpw@host:1080");
+  });
+});

--- a/packages/qwen-proxy/tests/upstream/baxia-token.test.ts
+++ b/packages/qwen-proxy/tests/upstream/baxia-token.test.ts
@@ -439,6 +439,127 @@ describe("BaxiaTokenManager", () => {
       expect(evalCount).toBe(3); // 2 failures + 1 success
     });
 
+    it("readinessTimeoutMs:6000 → 12 readiness evals, not-ready error", async () => {
+      const { BaxiaTokenManager } = await import("../../src/upstream/baxia-token");
+      const replyMap = new Map<string, (id: number, params: any) => any>();
+      replyMap.set("Page.enable", () => ({}));
+      replyMap.set("Runtime.enable", () => ({}));
+      replyMap.set("Page.navigate", () => ({ frameId: "f1" }));
+      replyMap.set("Runtime.evaluate", (_id, params) => {
+        if (params?.expression?.includes("__baxia__")) {
+          return { result: { type: "object", value: { ready: false } } };
+        }
+        return { result: { type: "undefined" } };
+      });
+
+      let readinessEvals = 0;
+      const origReply = replyMap.get("Runtime.evaluate")!;
+      replyMap.set("Runtime.evaluate", (_id, params) => {
+        if (params?.expression?.includes("fyObj")) readinessEvals++;
+        return origReply(_id, params);
+      });
+
+      const mgr = new BaxiaTokenManager(
+        makeConfig({
+          spawn: vi.fn(() => ({ pid: 1, kill: vi.fn() })) as any,
+          WebSocketCtor: function (url: string) {
+            return new FakeWebSocket(url, replyMap) as any;
+          } as any,
+          fetcher: vi.fn(async () => ({
+            ok: true,
+            json: async () => [{ type: "page", webSocketDebuggerUrl: "ws://127.0.0.1:9222/devtools/page/abc" }],
+          })) as any,
+          sleep: () => Promise.resolve(),
+          now: () => 1000,
+          readinessTimeoutMs: 6000,
+        }),
+      );
+
+      const p = mgr.ensureToken();
+      await expect(p).rejects.toMatchObject({ cause: "not-ready" });
+      await expect(p).rejects.toThrow(/6000/);
+      expect(readinessEvals).toBe(12); // 6000 / 500 = 12
+    });
+
+    it("readinessTimeoutMs:1000 clamps to 5000 → 10 readiness evals", async () => {
+      const { BaxiaTokenManager } = await import("../../src/upstream/baxia-token");
+      const replyMap = new Map<string, (id: number, params: any) => any>();
+      replyMap.set("Page.enable", () => ({}));
+      replyMap.set("Runtime.enable", () => ({}));
+      replyMap.set("Page.navigate", () => ({ frameId: "f1" }));
+      replyMap.set("Runtime.evaluate", (_id, params) => {
+        if (params?.expression?.includes("__baxia__")) {
+          return { result: { type: "object", value: { ready: false } } };
+        }
+        return { result: { type: "undefined" } };
+      });
+
+      let readinessEvals = 0;
+      const origReply = replyMap.get("Runtime.evaluate")!;
+      replyMap.set("Runtime.evaluate", (_id, params) => {
+        if (params?.expression?.includes("fyObj")) readinessEvals++;
+        return origReply(_id, params);
+      });
+
+      const mgr = new BaxiaTokenManager(
+        makeConfig({
+          spawn: vi.fn(() => ({ pid: 1, kill: vi.fn() })) as any,
+          WebSocketCtor: function (url: string) {
+            return new FakeWebSocket(url, replyMap) as any;
+          } as any,
+          fetcher: vi.fn(async () => ({
+            ok: true,
+            json: async () => [{ type: "page", webSocketDebuggerUrl: "ws://127.0.0.1:9222/devtools/page/abc" }],
+          })) as any,
+          sleep: () => Promise.resolve(),
+          now: () => 1000,
+          readinessTimeoutMs: 1000,
+        }),
+      );
+
+      await expect(mgr.ensureToken()).rejects.toMatchObject({ cause: "not-ready" });
+      expect(readinessEvals).toBe(10); // 1000 clamped to 5000 → ceil(5000/500)=10
+    });
+
+    it("readinessTimeoutMs omitted (default) → 60 readiness evals, not-ready", async () => {
+      const { BaxiaTokenManager } = await import("../../src/upstream/baxia-token");
+      const replyMap = new Map<string, (id: number, params: any) => any>();
+      replyMap.set("Page.enable", () => ({}));
+      replyMap.set("Runtime.enable", () => ({}));
+      replyMap.set("Page.navigate", () => ({ frameId: "f1" }));
+      replyMap.set("Runtime.evaluate", (_id, params) => {
+        if (params?.expression?.includes("__baxia__")) {
+          return { result: { type: "object", value: { ready: false } } };
+        }
+        return { result: { type: "undefined" } };
+      });
+
+      let readinessEvals = 0;
+      const origReply = replyMap.get("Runtime.evaluate")!;
+      replyMap.set("Runtime.evaluate", (_id, params) => {
+        if (params?.expression?.includes("fyObj")) readinessEvals++;
+        return origReply(_id, params);
+      });
+
+      const mgr = new BaxiaTokenManager(
+        makeConfig({
+          spawn: vi.fn(() => ({ pid: 1, kill: vi.fn() })) as any,
+          WebSocketCtor: function (url: string) {
+            return new FakeWebSocket(url, replyMap) as any;
+          } as any,
+          fetcher: vi.fn(async () => ({
+            ok: true,
+            json: async () => [{ type: "page", webSocketDebuggerUrl: "ws://127.0.0.1:9222/devtools/page/abc" }],
+          })) as any,
+          sleep: () => Promise.resolve(),
+          now: () => 1000,
+        }),
+      );
+
+      await expect(mgr.ensureToken()).rejects.toMatchObject({ cause: "not-ready" });
+      expect(readinessEvals).toBe(60); // ceil(30000/500) = 60
+    });
+
     it("kills child in finally even on failure", async () => {
       const { BaxiaTokenManager } = await import("../../src/upstream/baxia-token");
       const childKill = vi.fn();

--- a/packages/qwen-proxy/tests/upstream/baxia-token.test.ts
+++ b/packages/qwen-proxy/tests/upstream/baxia-token.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import * as fs from "node:fs";
 import type { BaxiaTokenManagerConfig } from "../../src/upstream/baxia-token";
+import { TokenMintError } from "../../src/upstream/errors";
 
 // Auto-mock node:fs so vi.spyOn/vi.mocked works with ESM namespace imports
 vi.mock("node:fs");
@@ -178,6 +179,64 @@ describe("BaxiaTokenManager", () => {
         makeConfig({ chromePath: undefined }),
       );
       await expect(mgr.ensureToken()).rejects.toThrow(/Chrome not found/i);
+      await expect(mgr.ensureToken()).rejects.toBeInstanceOf(TokenMintError);
+      await expect(mgr.ensureToken()).rejects.toMatchObject({ cause: "egress" });
+    });
+
+    it("fetcher never returns /json/list → TokenMintError(egress)", async () => {
+      const { BaxiaTokenManager } = await import("../../src/upstream/baxia-token");
+      const fetcherFn = vi.fn(async () => ({
+        ok: false,
+        json: async () => ({}),
+      }));
+      const replyMap = makeDefaultReplyMap();
+      const child = { pid: 1, kill: vi.fn() };
+
+      const mgr = new BaxiaTokenManager(
+        makeConfig({
+          spawn: vi.fn(() => child) as any,
+          WebSocketCtor: function (url: string) {
+            return new FakeWebSocket(url, replyMap) as any;
+          } as any,
+          fetcher: fetcherFn as any,
+          sleep: () => Promise.resolve(),
+          now: () => 1000,
+        }),
+      );
+
+      await expect(mgr.ensureToken()).rejects.toMatchObject({ cause: "egress" });
+      await expect(mgr.ensureToken()).rejects.toThrow(/never returned a page/i);
+    });
+
+    it("sync spawn throw → TokenMintError(egress)", async () => {
+      const { BaxiaTokenManager } = await import("../../src/upstream/baxia-token");
+      const replyMap = makeDefaultReplyMap();
+      const fetcherFn = vi.fn(async (url: string) => {
+        if (url.includes("/json/list")) {
+          return {
+            ok: true,
+            json: async () => [
+              { type: "page", webSocketDebuggerUrl: "ws://127.0.0.1:9222/devtools/page/abc" },
+            ],
+          };
+        }
+        return { ok: false, json: async () => ({}) };
+      });
+
+      const mgr = new BaxiaTokenManager(
+        makeConfig({
+          spawn: (() => { throw new Error("spawn EACCES"); }) as any,
+          WebSocketCtor: function (url: string) {
+            return new FakeWebSocket(url, replyMap) as any;
+          } as any,
+          fetcher: fetcherFn as any,
+          sleep: () => Promise.resolve(),
+          now: () => 1000,
+        }),
+      );
+
+      await expect(mgr.ensureToken()).rejects.toMatchObject({ cause: "egress" });
+      await expect(mgr.ensureToken()).rejects.toThrow(/chromium spawn failed/i);
     });
 
     // P0 regression: ensure internal _spawn is a real function, not a module namespace

--- a/packages/qwen-proxy/tests/upstream/baxia-token.test.ts
+++ b/packages/qwen-proxy/tests/upstream/baxia-token.test.ts
@@ -355,6 +355,125 @@ describe("BaxiaTokenManager", () => {
     });
   });
 
+  describe("mint fast-fail (chrome-error)", () => {
+    it("chrome-error:// → TokenMintError(egress), child kill called, ≤3 readiness evals", async () => {
+      const { BaxiaTokenManager } = await import("../../src/upstream/baxia-token");
+      const replyMap = new Map<string, (id: number, params: any) => any>();
+      replyMap.set("Page.enable", () => ({}));
+      replyMap.set("Runtime.enable", () => ({}));
+      replyMap.set("Page.navigate", () => ({ frameId: "f1" }));
+      replyMap.set("Runtime.evaluate", (_id, params) => {
+        if (params?.expression?.includes("__baxia__")) {
+          return { result: { type: "object", value: { ready: false, href: "chrome-error://chromewebdata/" } } };
+        }
+        return { result: { type: "undefined" } };
+      });
+
+      let readinessEvals = 0;
+      const origReply = replyMap.get("Runtime.evaluate")!;
+      replyMap.set("Runtime.evaluate", (_id, params) => {
+        if (params?.expression?.includes("fyObj")) readinessEvals++;
+        return origReply(_id, params);
+      });
+
+      const childKill = vi.fn();
+      const child = { pid: 2, kill: childKill };
+
+      const mgr = new BaxiaTokenManager(
+        makeConfig({
+          spawn: vi.fn(() => child) as any,
+          WebSocketCtor: function (url: string) {
+            return new FakeWebSocket(url, replyMap) as any;
+          } as any,
+          fetcher: vi.fn(async () => ({
+            ok: true,
+            json: async () => [{ type: "page", webSocketDebuggerUrl: "ws://127.0.0.1:9222/devtools/page/abc" }],
+          })) as any,
+          sleep: vi.fn(async () => {}),
+          now: () => 1000,
+        }),
+      );
+
+      const p = mgr.ensureToken();
+      await expect(p).rejects.toMatchObject({ cause: "egress" });
+      await expect(p).rejects.toThrow(/chrome-error/);
+      expect(readinessEvals).toBeLessThanOrEqual(3);
+      expect(childKill).toHaveBeenCalled();
+    });
+
+    it("qwen error page href → full timeout, not-ready", async () => {
+      const { BaxiaTokenManager } = await import("../../src/upstream/baxia-token");
+      const replyMap = new Map<string, (id: number, params: any) => any>();
+      replyMap.set("Page.enable", () => ({}));
+      replyMap.set("Runtime.enable", () => ({}));
+      replyMap.set("Page.navigate", () => ({ frameId: "f1" }));
+      replyMap.set("Runtime.evaluate", (_id, params) => {
+        if (params?.expression?.includes("__baxia__")) {
+          return { result: { type: "object", value: { ready: false, href: "https://chat.qwen.ai/error-503" } } };
+        }
+        return { result: { type: "undefined" } };
+      });
+
+      let readinessEvals = 0;
+      const origReply = replyMap.get("Runtime.evaluate")!;
+      replyMap.set("Runtime.evaluate", (_id, params) => {
+        if (params?.expression?.includes("fyObj")) readinessEvals++;
+        return origReply(_id, params);
+      });
+
+      const mgr = new BaxiaTokenManager(
+        makeConfig({
+          spawn: vi.fn(() => ({ pid: 1, kill: vi.fn() })) as any,
+          WebSocketCtor: function (url: string) {
+            return new FakeWebSocket(url, replyMap) as any;
+          } as any,
+          fetcher: vi.fn(async () => ({
+            ok: true,
+            json: async () => [{ type: "page", webSocketDebuggerUrl: "ws://127.0.0.1:9222/devtools/page/abc" }],
+          })) as any,
+          sleep: () => Promise.resolve(),
+          now: () => 1000,
+          readinessTimeoutMs: 6000,
+        }),
+      );
+
+      const p = mgr.ensureToken();
+      await expect(p).rejects.toMatchObject({ cause: "not-ready" });
+      expect(readinessEvals).toBe(12); // full timeout (6000/500=12)
+    });
+
+    it("normal qwen.ai href → not-ready after full timeout", async () => {
+      const { BaxiaTokenManager } = await import("../../src/upstream/baxia-token");
+      const replyMap = new Map<string, (id: number, params: any) => any>();
+      replyMap.set("Page.enable", () => ({}));
+      replyMap.set("Runtime.enable", () => ({}));
+      replyMap.set("Page.navigate", () => ({ frameId: "f1" }));
+      replyMap.set("Runtime.evaluate", (_id, params) => {
+        if (params?.expression?.includes("__baxia__")) {
+          return { result: { type: "object", value: { ready: false, href: "https://chat.qwen.ai/" } } };
+        }
+        return { result: { type: "undefined" } };
+      });
+
+      const mgr = new BaxiaTokenManager(
+        makeConfig({
+          spawn: vi.fn(() => ({ pid: 1, kill: vi.fn() })) as any,
+          WebSocketCtor: function (url: string) {
+            return new FakeWebSocket(url, replyMap) as any;
+          } as any,
+          fetcher: vi.fn(async () => ({
+            ok: true,
+            json: async () => [{ type: "page", webSocketDebuggerUrl: "ws://127.0.0.1:9222/devtools/page/abc" }],
+          })) as any,
+          sleep: () => Promise.resolve(),
+          now: () => 1000,
+        }),
+      );
+
+      await expect(mgr.ensureToken()).rejects.toMatchObject({ cause: "not-ready" });
+    });
+  });
+
   describe("getBaxiaTokens", () => {
     it("extracts bxUa=fy, bxUmidToken=uid, bxV=config version, gates /^T2gA/ len>20", async () => {
       const { BaxiaTokenManager } = await import("../../src/upstream/baxia-token");


### PR DESCRIPTION
## Why (live-debugged on mini)

When a Baxia token **mint** fails (spawn/readiness), rotation walks the entire pool at ~30s per spawn, each burning ~30 SOCKS5 auth handshakes — re-tripping NordVPN's per-server credential throttle in a self-amplifying storm (observed: 7 failed spawns ≈ 210 wasted auths in 5 min).

## What changed (7 user-resolved clarify decisions honored)

- **`TokenMintError`** (extends NetworkError) with cause `egress` (findChrome, /json/list, sync-spawn, CDP ws error/close, chrome-error fast-fail) or `not-ready` (page loaded, SDK never initialized). Exhaustive mint-site typing; no mint failure rotates unbudgeted.
- **chrome-error fast-fail**: page-state href rides the existing per-poll evaluate (zero extra CDP round-trips); throttled egress aborts in 1–2 polls instead of 30s.
- **`SF_QWEN_BAXIA_READINESS_TIMEOUT_MS`** (default 30000, clamp ≥5000) — documented in 4 env tables + 3 compose/env lists.
- **Per-request 2-strike mint budget** in both retry wrappers: 1st mint failure rotates (skip the bad proxy); 2nd consecutive → `markEmptyAndSwitch` + cooldown sleep → 429 (non-stream) / rateLimited sentinel (stream), **no bestEffortRefresh**. Inline re-mint failures count (emptyBurnStep `"mint-failed"` action); strikes reset on any successful mint/completion.
- **Walk-exhausted-with-mint-participation** also applies the cooldown gate (5 all-burned paths) — closes the mixed-error re-storm corner.
- **Rotation deadlock fix** (audit-found P1): `rotateWithSlot` now releases the current slot *before* acquiring the next — previously, all-slots-busy simultaneous rotation (the storm condition) deadlocked permanently with conc=2.
- **503 surfacing** in legacy mode (both OpenAI + Anthropic envelopes); log polish (readiness polls → info; mint failures log cause + redacted proxy).

## Validation

- **594/594 tests** (557 baseline + 37 new), typecheck clean — verified independently in the worktree.
- Gates: plan-review REVISE→APPROVED (5 findings fixed); impl-review APPROVED (0 findings); audit canonical-delta 2 rounds (5 findings fixed, incl. the P1 deadlock; APPROVED).
- 19 commits, hard rules clean (no version/CHANGELOG/guest-client changes).
- Live validation on mini after merge/release: all-bad-pool → sentinel within ≤2 spawns (not 9×30s) with cooldown; single throttled server fails fast (<10s) and rotates; no >50-handshake auth storms.
